### PR TITLE
Refactor Image to support image flow

### DIFF
--- a/metaviews/src/commonMain/kotlin/com/mirego/trikot/metaviews/MetaImage.kt
+++ b/metaviews/src/commonMain/kotlin/com/mirego/trikot/metaviews/MetaImage.kt
@@ -10,18 +10,34 @@ inline class ImageWidth(val value: Int)
 inline class ImageHeight(val value: Int)
 
 interface MetaImage : MetaView {
-    /**
-     * Online URL of the image to fetch according to the view Size
-     */
-    fun URL(width: ImageWidth, height: ImageHeight): Publisher<String?>
+    fun imageFlow(width: ImageWidth, height: ImageHeight): Publisher<ImageFlow>
+}
 
+interface ImageFlow {
     /**
-     * Image resource to display in the image
+     * Image resource to display as placeholder/static image
      */
-    val imageResource: Publisher<ImageResource>
-
+    val imageResource: ImageResource?
     /**
-     * Tint color to apply to the image resource
+     * Tint color to apply to the imageResource
      */
-    val tintColor: Publisher<Color>
+    val tintColor: Color?
+    /**
+     * Accessibility text
+     */
+    val accessibilityText: String?
+    /**
+     * URL to download the image from. When downloaded, it will replace the imageResource if any
+     */
+    val URL: String?
+    /**
+     * Next image flow to use when an URL is provided and the image is successfully displayed. Usefull when a low
+     * quality image needs to be displayed before a full quality image.
+     */
+    val onSuccess: Publisher<ImageFlow>?
+    /**
+     * Next image flow to use when an URL is provided and the image could not be downloaded/displayed. Usefull when a low
+     * quality image needs to be displayed before a full quality image.
+     */
+    val onError: Publisher<ImageFlow>?
 }

--- a/metaviews/src/commonMain/kotlin/com/mirego/trikot/metaviews/mutable/MutableMetaImage.kt
+++ b/metaviews/src/commonMain/kotlin/com/mirego/trikot/metaviews/mutable/MutableMetaImage.kt
@@ -1,63 +1,26 @@
 package com.mirego.trikot.metaviews.mutable
 
+import com.mirego.trikot.metaviews.ImageFlow
 import com.mirego.trikot.metaviews.ImageHeight
 import com.mirego.trikot.metaviews.ImageWidth
 import com.mirego.trikot.metaviews.MetaImage
-import com.mirego.trikot.metaviews.factory.PropertyFactory
 import com.mirego.trikot.metaviews.properties.Color
+import com.mirego.trikot.metaviews.properties.SimpleImageFlow
 import com.mirego.trikot.metaviews.resource.ImageResource
 import com.mirego.trikot.streams.reactive.PublisherFactory
 import org.reactivestreams.Publisher
 
-open class MutableMetaImage(
-    /**
-     * Constructor property
-     *
-     * Processor used to convert the url when the platform sets the size
-     * Could come really handy when we need to fetch a small image on a list and a large
-     * image on a detail view
-     */
-    var imageUrlProcessor: ImageURLProcessor = DefaultImageURLProcessor()
-) : MutableMetaView(), MetaImage {
+/**
+ * Block to execute to retrieve an imageFlow Publisher for a specific image size
+ */
+typealias ImageFlowProvider = (width: ImageWidth, height: ImageHeight) -> Publisher<ImageFlow>
 
-    /**
-     * Online URL of the image to fetch according to the view Size
-     */
-    override fun URL(width: ImageWidth, height: ImageHeight): Publisher<String?> {
-        return imageUrlProcessor.URLForSizeSize(width, height)
+open class MutableMetaImage(var imageFlowProvider: ImageFlowProvider = { _, _ -> PublisherFactory.create(null) }) : MutableMetaView(), MetaImage {
+    override fun imageFlow(width: ImageWidth, height: ImageHeight): Publisher<ImageFlow> {
+        return imageFlowProvider(width, height)
     }
-
-    /**
-     * Base url given to the processor. DefaultURLProcessor will dispatch this value.
-     */
-    fun setUrl(url: String?) { imageUrlProcessor.imageURL = url }
-
-    override val imageResource = PropertyFactory.create(ImageResource.None)
-
-    override val tintColor = PropertyFactory.create(Color.None)
 }
 
-/**
- * Image processor
- */
-interface ImageURLProcessor {
-    var imageURL: String?
-    fun URLForSizeSize(width: ImageWidth, height: ImageHeight): Publisher<String?>
-}
-
-/**
- * Default image processor that publish the url received without transformation
- */
-open class DefaultImageURLProcessor : ImageURLProcessor {
-    override var imageURL: String? = null
-        set(value) {
-            field = value
-            imageUrlPublisher.value = value
-        }
-
-    protected var imageUrlPublisher = PublisherFactory.create<String?>()
-
-    override fun URLForSizeSize(width: ImageWidth, height: ImageHeight): Publisher<String?> {
-        return imageUrlPublisher
-    }
+fun simpleImageFlowProvider(url: String? = null, imageResource: ImageResource? = null, tintColor: Color? = null): ImageFlowProvider {
+    return { _, _ -> PublisherFactory.create(SimpleImageFlow(URL = url, imageResource = imageResource, tintColor = tintColor)) }
 }

--- a/metaviews/src/commonMain/kotlin/com/mirego/trikot/metaviews/properties/SimpleImageFlow.kt
+++ b/metaviews/src/commonMain/kotlin/com/mirego/trikot/metaviews/properties/SimpleImageFlow.kt
@@ -1,0 +1,14 @@
+package com.mirego.trikot.metaviews.properties
+
+import com.mirego.trikot.metaviews.ImageFlow
+import com.mirego.trikot.metaviews.resource.ImageResource
+import org.reactivestreams.Publisher
+
+open class SimpleImageFlow(
+    override val imageResource: ImageResource? = null,
+    override val tintColor: Color? = null,
+    override val accessibilityText: String? = null,
+    override val URL: String? = null,
+    override val onSuccess: Publisher<ImageFlow>? = null,
+    override val onError: Publisher<ImageFlow>? = null
+) : ImageFlow


### PR DESCRIPTION
Instead of assigning an URL, we assign an ImageFlow.

ImageFlow allow cascading of URL downloading in case of success or error. They also have a better contract than a standard ImageResource, Placeholder, URL approach.