### PR TITLE
Modify UITextFieldExtensions to add text value to userInput

### DIFF
--- a/swift-extensions/UITextFieldExtensions.swift
+++ b/swift-extensions/UITextFieldExtensions.swift
@@ -10,11 +10,15 @@ extension UITextField {
             if let metaInputText = value {
                 addTarget(self, action: #selector(onEditingChanged), for: .editingChanged)
 
-                bind(metaInputText.text, \UITextField.text)
                 bindColorSelectorDefaultValue(metaInputText.textColor, \UITextField.textColor)
 
                 observe(metaInputText.placeholderText) {[weak self] (placeholder: String) in
                     self?.placeholder = placeholder
+                }
+
+                observe(metaInputText.text) {[weak self] (text: String) in
+                    self?.text = text
+                    self?.metaInputText?.setUserInput(value: text)
                 }
 
                 observe(metaInputText.inputType) {[weak self] (inputType: InputType_) in


### PR DESCRIPTION
Le bind sur `metaInputText.text` mettait à jour le texte dans input field, mais pas le user input.

Résultat : le user envoyait un input vide alors que le field était rempli.