### PR TITLE
Verify if selector has any value before applying background

### DIFF
--- a/android-ktx/src/main/java/com/mirego/trikot/metaviews/MetaButtonBinder.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/metaviews/MetaButtonBinder.kt
@@ -151,28 +151,30 @@ object MetaButtonBinder {
 
             it.backgroundColor.asLiveData()
                 .observe(lifecycleOwnerWrapper.lifecycleOwner) { selector ->
-                    if (selector.hasAnyValue) {
-                        val defaultColor =
-                            Color.parseColor(selector.default?.hexARGB("#") ?: "#00000000")
-                        val hoveredColor =
-                            selector.highlighted?.let { Color.parseColor(it.hexARGB("#")) }
-                                ?: defaultColor
-                        val selectedColor =
-                            selector.selected?.let { Color.parseColor(it.hexARGB("#")) }
-                                ?: defaultColor
-                        val disabledColor =
-                            selector.disabled?.let { Color.parseColor(it.hexARGB("#")) }
-                                ?: defaultColor
-                        button.backgroundTintList = ColorStateList(
-                            arrayOf(
-                                intArrayOf(R.attr.state_enabled),
-                                intArrayOf(R.attr.state_hovered),
-                                intArrayOf(R.attr.state_selected),
-                                intArrayOf(-R.attr.state_enabled)
-                            ),
-                            intArrayOf(defaultColor, hoveredColor, selectedColor, disabledColor)
-                        )
+                    if (!selector.hasAnyValue) {
+                        return@observe
                     }
+
+                    val defaultColor =
+                        Color.parseColor(selector.default?.hexARGB("#") ?: "#00000000")
+                    val hoveredColor =
+                        selector.highlighted?.let { Color.parseColor(it.hexARGB("#")) }
+                            ?: defaultColor
+                    val selectedColor =
+                        selector.selected?.let { Color.parseColor(it.hexARGB("#")) }
+                            ?: defaultColor
+                    val disabledColor =
+                        selector.disabled?.let { Color.parseColor(it.hexARGB("#")) }
+                            ?: defaultColor
+                    button.backgroundTintList = ColorStateList(
+                        arrayOf(
+                            intArrayOf(R.attr.state_enabled),
+                            intArrayOf(R.attr.state_hovered),
+                            intArrayOf(R.attr.state_selected),
+                            intArrayOf(-R.attr.state_enabled)
+                        ),
+                        intArrayOf(defaultColor, hoveredColor, selectedColor, disabledColor)
+                    )
                 }
 
             it.textColor.asLiveData()


### PR DESCRIPTION
If no background is set in MetaButton, an invisible background was set by default. The problem is that a background configured in the xml was overwritten by the invisible one.