### PR TITLE
Fix missing freeze in ImageFlow

### DIFF
--- a/swift-extensions/UIImageViewExtensions.swift
+++ b/swift-extensions/UIImageViewExtensions.swift
@@ -172,6 +172,7 @@ public class DefaultImageViewModelHandler: ImageViewModelHandler {
             }
         } else {
             MrFreeze().freeze(objectToFreeze: cancellableManager)
+            MrFreeze().freeze(objectToFreeze: imageFlow)
 
             let dataTask = URLSession.shared.dataTask(with: url) { [weak imageView, weak self] data, response, error in
                 DispatchQueue.main.async {


### PR DESCRIPTION
## Description
Make sure imageFlow is frozen before switching thread.

## Motivation and Context
When `Trikot.streams`'s improved their thread management to prevent freezing of subscriber, we might come to a state where imageFlow is not frozen before downloading an image.


## How Has This Been Tested?
In a separate application

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
