### PR TITLE
Remove image view scaletype override from binding

### DIFF
--- a/android-ktx/src/main/java/com/mirego/trikot/viewModels/ImageViewModelBinder.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/viewModels/ImageViewModelBinder.kt
@@ -71,7 +71,6 @@ object ImageViewModelBinder {
         imageFlow.imageResource?.asDrawable(
             imageView.context,
             imageFlow.tintColor?.let { StateSelector(imageFlow.tintColor) })?.let {
-            imageView.scaleType = ImageView.ScaleType.CENTER_INSIDE
             imageView.setImageDrawable(it)
             imageViewModel.setImageState(ImageState.SUCCESS)
         } ?: run {
@@ -131,7 +130,6 @@ object ImageViewModelBinder {
                 })
             } ?: run {
                 imageFlow.placeholderImageResource?.asDrawable(imageView.context)?.let {
-                    imageView.scaleType = ImageView.ScaleType.CENTER_INSIDE
                     imageView.setImageDrawable(it)
                 }
             }


### PR DESCRIPTION
## Description
We should not override scaletype with an arbitrary one from the binding.
This removes that from the image view binding.

`FIT_CENTER` being the default scale type of an ImageView, applications that relied on this to have `CENTER_INSIDE` will need to set it in their views.

## Motivation and Context
We had a specific scale type for a local image in our project and it was replaced by `CENTER_INSIDE`.
In our case it was `FIT_CENTER` + `adjustViewBounds` but any other scale type would have been overridden.

## How Has This Been Tested?
This was tested in the project where the problem was found.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
