### PR TITLE
Change the defautl value of hidden and alpha to “never”

### DIFF
--- a/viewModels/src/commonMain/kotlin/com/mirego/trikot/viewModels/factory/PropertyFactory.kt
+++ b/viewModels/src/commonMain/kotlin/com/mirego/trikot/viewModels/factory/PropertyFactory.kt
@@ -5,4 +5,5 @@ import org.reactivestreams.Publisher
 
 object PropertyFactory {
     fun <T> create(value: T): Publisher<T> = Publishers.just(value)
+    fun <T> never(): Publisher<T> = Publishers.never()
 }

--- a/viewModels/src/commonMain/kotlin/com/mirego/trikot/viewModels/mutable/MutableViewModel.kt
+++ b/viewModels/src/commonMain/kotlin/com/mirego/trikot/viewModels/mutable/MutableViewModel.kt
@@ -7,11 +7,11 @@ import com.mirego.trikot.viewmodels.properties.StateSelector
 import com.mirego.trikot.viewmodels.properties.ViewModelAction
 
 open class MutableViewModel : ViewModel {
-    override var alpha = PropertyFactory.create(1f)
+    override var alpha = PropertyFactory.never<Float>()
 
     override var backgroundColor = PropertyFactory.create(StateSelector<Color>())
 
-    override var hidden = PropertyFactory.create(false)
+    override var hidden = PropertyFactory.never<Boolean>()
 
     override var action = PropertyFactory.create(ViewModelAction.None)
 }


### PR DESCRIPTION
## Description
When we want to change the default value of the properties alpha or hidden on the platform side, often to do an animation, we don't want the binding to have those values reset by default to "alpha = 1" and "hidden = false" when the binding occurs

## Motivation and Context
I think that changing the default value to "never" will save debugging time when other people will try to play with those properties on the native side.

This should not make any breaking change because the default values of "alpha = 1" and "hidden = false" is also the default of all platforms.

## How Has This Been Tested?
In my project

## Types of changes
- [X] Defaults values updated (non-breaking change 🤞)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
