### PR TITLE
Update trikot dependencies versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 kotlin.code.style=official
 kotlin_version=1.3.70
-trikot_foundation_version=0.30.1
-trikot_streams_version=0.63.1
-trikot_streams_android_ktx_version=0.33.1
+trikot_foundation_version=0.31.1
+trikot_streams_version=0.68.1
+trikot_streams_android_ktx_version=0.34.1
 androidx_lifecycle_version=2.2.0
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
## Description

I have a weird compilation error in my project: 

`e: Compilation failed: Could not find serialized descriptor for index: -5468675969041219556 com.mirego.trikot.streams.reactive,BehaviorSubjectImpl,<init>
`

Update trikot dependencies here fixed my problem.

## How Has This Been Tested?
In my project

