### PR TITLE
Fix compilation failure on tvOS due to UISliderExtensions

### DIFF
--- a/Trikot.viewmodels.podspec
+++ b/Trikot.viewmodels.podspec
@@ -8,7 +8,9 @@ Pod::Spec.new do |spec|
   spec.author        = { "Martin Gagnon" => "mgagnon@mirego.com" }
   spec.source        = { :git => "https://github.com/mirego/trikot.viewmodels.git", :tag => "#{spec.version}" }
   spec.source_files  = "swift-extensions/*.swift"
-  
+  spec.tvos.source_files = "swift-extensions/*.swift"
+  spec.tvos.exclude_files = "swift-extensions/UISliderExtensions.swift"
+
   spec.static_framework = true
   
   spec.dependency 'Trikot.streams'

--- a/swift-extensions/UISliderExtensions.swift
+++ b/swift-extensions/UISliderExtensions.swift
@@ -1,5 +1,3 @@
-#if os(iOS)
-
 import UIKit
 import TRIKOT_FRAMEWORK_NAME
 
@@ -88,4 +86,3 @@ extension UISlider {
         }
     }
 }
-#endif

--- a/swift-extensions/UISliderExtensions.swift
+++ b/swift-extensions/UISliderExtensions.swift
@@ -1,3 +1,5 @@
+#if os(iOS)
+
 import UIKit
 import TRIKOT_FRAMEWORK_NAME
 
@@ -86,3 +88,4 @@ extension UISlider {
         }
     }
 }
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We make sure to compile UISliderExtensions only if the os is iOS.

## Motivation and Context
<!--- Why is those changes required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On tvOS, the `UISlider` class does not exist so the `UISliderExtensions` caused compilation errors. By specifying to compile the extension only on iOS solved the issue.

## How Has This Been Tested?
- [ ] All features has been added/updated in sample application ( /sample )
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in my project



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
