### PR TITLE
Fix attributedTitle never set on UIButton if no textColor is specified on viewModel

### DIFF
--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -17,7 +17,7 @@ DEPENDENCIES:
   - ViewModelsSample (from `../common`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - SwiftLint
 
 EXTERNAL SOURCES:
@@ -30,10 +30,10 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Trikot.streams:
-    :commit: ebbd2af8e85f982652bbbad5b7ca6df26ec72bf5
+    :commit: b0ab7497c3a6f2a49dd4071e58a20062d19bcf1e
     :git: "git@github.com:mirego/trikot.streams.git"
   Trikot.viewmodels:
-    :commit: 87c9f442077236f4271b334a20dcd4766e752728
+    :commit: a0e36d445d4667bf8f03ee246860b9b12760556e
     :git: "git@github.com:mirego/trikot.viewmodels.git"
 
 SPEC CHECKSUMS:

--- a/sample/ios/iosApp/sample/SampleView.swift
+++ b/sample/ios/iosApp/sample/SampleView.swift
@@ -22,7 +22,7 @@ class ListView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        backgroundColor = .white
+        backgroundColor = .black
         addSubview(tableView)
         tableView.dataSource = self
         tableView.delegate = self


### PR DESCRIPTION
## Description
In the case where a UIButton is used with rich text defined in the kmp code but no `.textColor` is specified, the attributedTitle was never set on the button. This regression was introduced in #58 

Fixing this allows the platforms to use the richText property in the common code while at the same time controlling the textColor and keeps the behaviour inline with Android

## Motivation and Context
Fix a regression

## How Has This Been Tested?
Locally in my application and in the sample app, both had the regression and now both are fixed

## Screenshots of sample application ( /sample ) (if appropriate):

Before [empty `.richText` button] | After [text back on `.richText` button]
---- | ----
![IMG_1875](https://user-images.githubusercontent.com/87188/98578723-b3f66500-228b-11eb-8f92-6d913eefea05.png) | ![IMG_1873](https://user-images.githubusercontent.com/87188/98578743-bb1d7300-228b-11eb-95f4-16b27a76982b.png)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
