### PR TITLE
Add Kingfisher image handler implementation w/ subspec

### DIFF
--- a/Trikot.viewmodels.podspec
+++ b/Trikot.viewmodels.podspec
@@ -7,16 +7,27 @@ Pod::Spec.new do |spec|
   spec.license       = "MIT license"
   spec.author        = { "Martin Gagnon" => "mgagnon@mirego.com" }
   spec.source        = { :git => "https://github.com/mirego/trikot.viewmodels.git", :tag => "#{spec.version}" }
-  spec.source_files  = "swift-extensions/*.swift"
-  spec.tvos.source_files = "swift-extensions/*.swift"
-  spec.tvos.exclude_files = "swift-extensions/UISliderExtensions.swift"
-
   spec.static_framework = true
-  
+
   spec.dependency 'Trikot.streams'
   spec.dependency ENV['TRIKOT_FRAMEWORK_NAME']
 
+  spec.default_subspec = 'viewmodels'
+
+  spec.subspec 'viewmodels' do |vms|
+   spec.source_files  = "swift-extensions/*.swift"
+   spec.tvos.source_files = "swift-extensions/*.swift"
+   spec.tvos.exclude_files = "swift-extensions/UISliderExtensions.swift"
+  end
+
+  spec.subspec 'Kingfisher' do |kf|
+    kf.source_files = 'swift-extensions/kingfisher/*.swift'
+    kf.dependency 'Kingfisher', '5.15.7'
+    kf.ios.deployment_target = '10.0'
+  end
+
   spec.prepare_command = <<-CMD
     sed -i '' "s/TRIKOT_FRAMEWORK_NAME/${TRIKOT_FRAMEWORK_NAME}/g" ./**/*.swift
+    sed -i '' "s/TRIKOT_FRAMEWORK_NAME/${TRIKOT_FRAMEWORK_NAME}/g" ./**/**/*.swift
   CMD
 end

--- a/sample/ios/Podfile
+++ b/sample/ios/Podfile
@@ -8,8 +8,9 @@ target 'iosApp' do
   use_frameworks!
   pod 'SwiftLint'
   pod 'ViewModelsSample', :path => '../common'
-  pod 'Trikot.viewmodels', :git => 'git@github.com:mirego/trikot.viewmodels.git', :inhibit_warnings => true
   pod 'Trikot.streams', :git => 'git@github.com:mirego/trikot.streams.git', :inhibit_warnings => true
+  pod 'Trikot.viewmodels', :path => '../..', :inhibit_warnings => true
+  pod 'Trikot.viewmodels/Kingfisher', :path => '../..', :inhibit_warnings => true
     
   target 'iosAppTests' do
     inherit! :search_paths

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -1,4 +1,7 @@
 PODS:
+  - Kingfisher (5.15.7):
+    - Kingfisher/Core (= 5.15.7)
+  - Kingfisher/Core (5.15.7)
   - SwiftLint (0.41.0)
   - Trikot.streams (0.0.1):
     - Trikot.streams/streams (= 0.0.1)
@@ -7,24 +10,34 @@ PODS:
     - ViewModelsSample
   - Trikot.viewmodels (0.0.1):
     - Trikot.streams
+    - Trikot.viewmodels/viewmodels (= 0.0.1)
+    - ViewModelsSample
+  - Trikot.viewmodels/Kingfisher (0.0.1):
+    - Kingfisher (= 5.15.7)
+    - Trikot.streams
+    - ViewModelsSample
+  - Trikot.viewmodels/viewmodels (0.0.1):
+    - Trikot.streams
     - ViewModelsSample
   - ViewModelsSample (0.0.1)
 
 DEPENDENCIES:
   - SwiftLint
   - "Trikot.streams (from `git@github.com:mirego/trikot.streams.git`)"
-  - "Trikot.viewmodels (from `git@github.com:mirego/trikot.viewmodels.git`)"
+  - Trikot.viewmodels (from `../..`)
+  - Trikot.viewmodels/Kingfisher (from `../..`)
   - ViewModelsSample (from `../common`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
+    - Kingfisher
     - SwiftLint
 
 EXTERNAL SOURCES:
   Trikot.streams:
     :git: "git@github.com:mirego/trikot.streams.git"
   Trikot.viewmodels:
-    :git: "git@github.com:mirego/trikot.viewmodels.git"
+    :path: "../.."
   ViewModelsSample:
     :path: "../common"
 
@@ -32,16 +45,14 @@ CHECKOUT OPTIONS:
   Trikot.streams:
     :commit: 09fe72e21ed09381f269d7e14601379a0522fbed
     :git: "git@github.com:mirego/trikot.streams.git"
-  Trikot.viewmodels:
-    :commit: 5ed2ffdc7168c54cdf3e2aa060f5adaa05355c41
-    :git: "git@github.com:mirego/trikot.viewmodels.git"
 
 SPEC CHECKSUMS:
+  Kingfisher: 6e1a13523fcb1c86924ce53affe4ac957e544d59
   SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
   Trikot.streams: 495aae8afde3c2c3c5d08124d0e1c0c038108c4d
-  Trikot.viewmodels: 6666c31b2e5a02aca1637b5cbd1e6b5beec42a98
+  Trikot.viewmodels: 06e2565c50b234dd69bd7f9515aaed78e2b9aefd
   ViewModelsSample: 29f81b212b7a50e8594c43aba05578c83b8eb4d6
 
-PODFILE CHECKSUM: 2205ff78669d15fd3d2349490c9ff827a892fd2d
+PODFILE CHECKSUM: 529ebcc52fe7ad5afe034eaf0a11732238d8ca0a
 
 COCOAPODS: 1.7.3

--- a/sample/ios/iosApp/AppDelegate.swift
+++ b/sample/ios/iosApp/AppDelegate.swift
@@ -1,3 +1,4 @@
+import Kingfisher
 import UIKit
 import ViewModelsSample
 import Trikot_viewmodels
@@ -11,6 +12,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, NavigationDelegate {
         Environment().flavor = CurrentFlavor()
         ImageViewModelResourceManager.shared = SampleImageResourceProvider()
         TextAppearanceViewModelResourceManager.shared = SampleTextAppearanceResourceProvider()
+
+        initializeKingfisher()
 
         let window = UIWindow(frame: UIScreen.main.bounds)
         self.window = window
@@ -49,5 +52,35 @@ class AppDelegate: UIResponder, UIApplicationDelegate, NavigationDelegate {
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
 
         navigationController.present(alert, animated: true)
+    }
+
+    // MARK: - Kingfisher
+
+    private func initializeKingfisher() {
+        ImageCache.default.memoryStorage.config.totalCostLimit =
+            min(ImageCache.default.memoryStorage.config.totalCostLimit, 300 * 1_024 * 1_024) // Max to 300 MB
+        ImageCache.default.diskStorage.config.sizeLimit = 500 * 1_024 * 1_024 // 500 MB
+
+        let imageHandler = KFImageViewModelHandler()
+        imageHandler.delegate = self
+        UIImageView.imageViewModelHandler = imageHandler
+    }
+}
+
+// MAR: - KFImageUrlRequestModifierDelegate
+
+extension AppDelegate: KFImageUrlRequestModifierDelegate {
+
+    func requestModifier(for url: URL) -> ImageDownloadRequestModifier {
+        AnyModifier { request in
+            var authenticatedRequest = request
+
+            let accessToken = "get your current access token if needed"
+            if url.absoluteString.lowercased().hasPrefix("https://") {
+                authenticatedRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+            }
+
+            return authenticatedRequest
+        }
     }
 }

--- a/swift-extensions/kingfisher/KFImageViewModelHandler.swift
+++ b/swift-extensions/kingfisher/KFImageViewModelHandler.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Kingfisher
+import TRIKOT_FRAMEWORK_NAME
+import Trikot_streams
+import UIKit
+
+public protocol KFImageUrlRequestModifierDelegate: AnyObject {
+    func requestModifier(for url: URL) -> ImageDownloadRequestModifier
+}
+
+public class KFImageViewModelHandler: ImageViewModelHandler {
+
+    public weak var delegate: KFImageUrlRequestModifierDelegate?
+    
+    public var isImageDependantOnViewSize = false
+    public var sizeMultiplier: CGFloat = UIScreen.main.scale
+
+    public init() {}
+
+    public func handleImage(imageViewModel: ImageViewModel?, on imageView: UIImageView) {
+        guard let imageViewModel = imageViewModel else {
+            imageView.unsubscribeFromAllPublisher()
+            return
+        }
+
+        imageView.image = nil
+        imageView.restoreContentMode()
+        
+        let imageFlowPublisher = imageViewModel.imageFlow(
+            width: Int32(imageView.frame.width * sizeMultiplier),
+            height: Int32(imageView.frame.height * sizeMultiplier)
+        )
+        
+        let cancellableManagerProvider = CancellableManagerProvider()
+        
+        observeImageFlow(
+            imageFlowPublisher,
+            cancellableManager: cancellableManagerProvider.cancelPreviousAndCreate(),
+            imageViewModel: imageViewModel,
+            imageView: imageView
+        )
+        
+        imageView.trikotInternalPublisherCancellableManager.add(cancellable: cancellableManagerProvider)
+    }
+    
+    private func observeImageFlow(
+        _ imageFlowPublisher: Publisher,
+        cancellableManager: CancellableManager,
+        imageViewModel: ImageViewModel,
+        imageView: UIImageView
+    ) {
+        let cancellableManagerProvider = CancellableManagerProvider()
+        cancellableManager.add(cancellable: cancellableManagerProvider)
+
+        imageView.observe(cancellableManager: cancellableManager, publisher: imageFlowPublisher) {[weak self] (imageFlow: ImageFlow) in
+            self?.doLoadImageFlow(
+                cancellableManager: cancellableManagerProvider.cancelPreviousAndCreate(),
+                imageViewModel: imageViewModel,
+                imageFlow: imageFlow,
+                imageView: imageView
+            )
+        }
+    }
+    
+    private func doLoadImageFlow(
+        cancellableManager: CancellableManager,
+        imageViewModel: ImageViewModel,
+        imageFlow: ImageFlow,
+        imageView: UIImageView
+    ) {
+        var unProcessedImage: UIImage?
+        
+        if let imageResource = imageFlow.imageResource {
+            unProcessedImage = ImageViewModelResourceManager.shared.image(fromResource: imageResource)
+            imageViewModel.setImageState(imageState: ImageState.success)
+        }
+        
+        if let imageResource = imageFlow.placeholderImageResource {
+            if let placeholderContentMode = imageView.placeholderContentMode {
+                imageView.saveContentMode()
+                imageView.contentMode = placeholderContentMode
+            }
+            unProcessedImage = ImageViewModelResourceManager.shared.image(fromResource: imageResource)
+        }
+        
+        if let unProcessedImage = unProcessedImage {
+            if let tintColor = imageFlow.tintColor {
+                imageView.image = unProcessedImage.imageWithTintColor(tintColor.color())
+            } else {
+                imageView.image = unProcessedImage
+            }
+        }
+
+        downloadImageFlowIfNeeded(
+            cancellableManager: cancellableManager,
+            imageViewModel: imageViewModel,
+            imageFlow: imageFlow,
+            imageView: imageView
+        )
+    }
+    
+    private func downloadImageFlowIfNeeded(
+        cancellableManager: CancellableManager,
+        imageViewModel: ImageViewModel,
+        imageFlow: ImageFlow,
+        imageView: UIImageView
+    ) {
+        guard let urlString = imageFlow.url, let url = URL(string: urlString) else { return }
+        
+        var options: KingfisherOptionsInfo = []
+        if let modifier = delegate?.requestModifier(for: url) {
+            options.append(.requestModifier(modifier))
+        }
+
+        //swiftlint:disable:next trailing_closure
+        let task = imageView.kf.setImage(with: url, options: options, completionHandler: { [weak self] result in
+            MrFreeze().freeze(objectToFreeze: cancellableManager)
+            MrFreeze().freeze(objectToFreeze: imageFlow)
+            
+            switch result {
+            case .success:
+                if let onSuccess = imageFlow.onSuccess {
+                    self?.observeImageFlow(
+                        onSuccess,
+                        cancellableManager: cancellableManager,
+                        imageViewModel: imageViewModel,
+                        imageView: imageView
+                    )
+                } else {
+                    imageViewModel.setImageState(imageState: ImageState.success)
+                }
+            case .failure:
+                if let onError = imageFlow.onError {
+                    self?.observeImageFlow(
+                        onError,
+                        cancellableManager: cancellableManager,
+                        imageViewModel: imageViewModel,
+                        imageView: imageView
+                    )
+                } else {
+                    imageViewModel.setImageState(imageState: ImageState.error)
+                }
+            }
+        })
+        
+        cancellableManager.add { task?.cancel() }
+    }
+}


### PR DESCRIPTION
## Description
Add custom ImageViewModelHandler implementation using [KingFisher](https://github.com/onevcat/Kingfisher).

## Motivation and Context

KingFisher is more flexible than our default implementation, and allows us to easily [modify image requests before sending](https://github.com/onevcat/Kingfisher/wiki/Cheat-Sheet#modify-a-request-before-sending), especially useful when authentication headers need to be passed to the request.

KingFisher also allows [built-in cache handling](https://github.com/onevcat/Kingfisher/wiki/Cheat-Sheet#cache), which make it much easier for our implementation.

## How Has This Been Tested?
- [x] All features has been added/updated in sample application ( /sample )

This has been tested in the sample application as well as the current project I'm currently working on.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
