### PR TITLE
Update Kotlin version to 1.4.20

### DIFF
--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -21,12 +21,12 @@ repositories {
 group 'com.mirego.trikot.viewmodels'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion "29.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 29
+        targetSdkVersion 30
     }
 
     dataBinding {
@@ -40,7 +40,7 @@ configurations.all {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    api 'com.mirego.trikot:viewmodels:1.0.3'
+    api 'com.mirego.trikot:viewmodels:1.0.5'
     implementation "com.mirego.trikot:android-ktx:$trikot_streams_android_ktx_version"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 kotlin.code.style=official
-kotlin_version=1.4.0
-trikot_foundation_version=1.0.0
-trikot_streams_version=1.0.0
-trikot_streams_android_ktx_version=1.0.0
+kotlin_version=1.4.20
+trikot_foundation_version=1.0.21
+trikot_streams_version=1.0.6
+trikot_streams_android_ktx_version=1.0.1
 androidx_lifecycle_version=2.2.0
 android.useAndroidX=true
 android.enableJetifier=true

--- a/viewModels/build.gradle
+++ b/viewModels/build.gradle
@@ -17,11 +17,11 @@ repositories {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 29
+        targetSdkVersion 30
     }
 }
 


### PR DESCRIPTION
Update Kotlin version to 1.4.20

## Description
Update Kotlin to `1.4.20` and bump dependencies version numbers to compatible versions using the same version of Kotlin.

## Motivation and Context
Keep it up to date

## How Has This Been Tested?
No code change, untested.

## Types of changes
- [x] Update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
