### PR TITLE
Replaced touchUpInside by primaryActionTriggered on UIButton for better universal support

### DIFF
--- a/swift-extensions/UIButtonExtensions.swift
+++ b/swift-extensions/UIButtonExtensions.swift
@@ -18,7 +18,7 @@ extension UIButton {
     public var buttonViewModel: ButtonViewModel? {
         get { return trikotViewModel() }
         set(value) {
-            removeTarget(self, action: #selector(onButtonTouchUp), for: .touchUpInside)
+            removeTarget(self, action: #selector(onPrimaryActionTriggered), for: .primaryActionTriggered)
             viewModel = value
             if let buttonViewModel = value {
                 trikotInternalPublisherCancellableManager.add(cancellable: KeyValueObservationHolder(self.observe(\UIButton.isHighlighted) { (button, _) in
@@ -37,9 +37,9 @@ extension UIButton {
                     guard let self = self else { return }
                     self.tapAction = tapAction
                     if tapAction == ViewModelAction.Companion().None {
-                        self.removeTarget(self, action: #selector(self.onButtonTouchUp), for: .touchUpInside)
+                        self.removeTarget(self, action: #selector(self.onPrimaryActionTriggered), for: .primaryActionTriggered)
                     } else {
-                        self.addTarget(self, action: #selector(self.onButtonTouchUp), for: .touchUpInside)
+                        self.addTarget(self, action: #selector(self.onPrimaryActionTriggered), for: .primaryActionTriggered)
                     }
                 }
 
@@ -205,7 +205,7 @@ extension UIButton {
     }
 
     @objc
-    private func onButtonTouchUp() {
+    private func onPrimaryActionTriggered() {
         guard let tapAction = tapAction else { return }
         tapAction.execute(actionContext: self)
     }


### PR DESCRIPTION
## Motivation and Context
In Swift, when we bind a `ButtonViewModel` to a `UIButton` through `UIButtonExtensions`, we are adding a target on `.touchUpInside` in order to trigger the view model's action. While this works wonderfully on iOS, the same button's action won't be activated on tvOS.

In order to have a better support for tvOS, we need to use the `.primaryActionTriggered` target on the action's binding, as it does exactly the same thing as `.touchUpInside` for the `UIButton` component, but with a support for tvOS.

## How Has This Been Tested?
- Compiled with local Podfile and tested on a custom tvOS & iOS project

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)