### PR TITLE
Expose rich text handling methods outside the lib

### DIFF
--- a/swift-extensions/TextAppearanceViewModelResourceManager.swift
+++ b/swift-extensions/TextAppearanceViewModelResourceManager.swift
@@ -2,7 +2,7 @@ import UIKit
 import TRIKOT_FRAMEWORK_NAME
 
 public struct TextAppearanceAttributes {
-    let attributes: [NSAttributedString.Key: Any]
+    public let attributes: [NSAttributedString.Key: Any]
 
     public init(attributes: [NSAttributedString.Key: Any] = [:]) {
         self.attributes = attributes

--- a/swift-extensions/UIViewExtensions.swift
+++ b/swift-extensions/UIViewExtensions.swift
@@ -55,7 +55,7 @@ extension UIView {
         observe(viewModelModel.action.first()) {[weak self] (value: ViewModelAction) in value.execute(actionContext: self) }
     }
 
-    func richTextToAttributedString(_ richText: RichText, referenceFont: UIFont) -> NSAttributedString {
+    public func richTextToAttributedString(_ richText: RichText, referenceFont: UIFont) -> NSAttributedString {
         let attributedString = NSMutableAttributedString(string: richText.text)
         richText.ranges.forEach { (richTextRange) in
 
@@ -93,7 +93,7 @@ extension UIView {
         return attributedString
     }
 
-    private func fontWithTrait(_ trait: UIFontDescriptor.SymbolicTraits, referenceFont: UIFont) -> UIFont {
+    public func fontWithTrait(_ trait: UIFontDescriptor.SymbolicTraits, referenceFont: UIFont) -> UIFont {
         if let fontDescriptor = referenceFont.fontDescriptor.withSymbolicTraits(trait) {
             return UIFont(descriptor: fontDescriptor, size: referenceFont.pointSize)
         } else {


### PR DESCRIPTION
## Description
Make public 3 key parts of rich text handling:
- UIView.richTextToAttributedString
- UIView.fontWithTrait
- TextAppearanceAttributes.attributes 

That way, they can be reused for custom implementations

## Motivation and Context
Working on improving the performance our handling of richText so it can more easily be used in complex UICollectionViewCell

## How Has This Been Tested?
No testing really required, just changing the visibility 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
