### PR TITLE
Expose enabled state on InputTextViewModel & ToggleSwitchViewModel

### DIFF
--- a/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/InputTextViewModel.kt
+++ b/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/InputTextViewModel.kt
@@ -31,4 +31,9 @@ interface InputTextViewModel : ViewModel {
      * Return true if you have consumed the action, else false.
      */
     val editorAction: Publisher<InputTextEditorAction>
+
+    /**
+     * If the inputText is enabled or disabled
+     */
+    val enabled: Publisher<Boolean>
 }

--- a/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/ToggleSwitchViewModel.kt
+++ b/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/ToggleSwitchViewModel.kt
@@ -12,4 +12,9 @@ interface ToggleSwitchViewModel : ViewModel {
      * Set the state defined by the platform switch
      */
     fun setIsOn(on: Boolean)
+
+    /**
+     * If the ToggleSwitch is enabled or disabled
+     */
+    val enabled: Publisher<Boolean>
 }

--- a/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/mutable/MutableInputTextViewModel.kt
+++ b/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/mutable/MutableInputTextViewModel.kt
@@ -22,5 +22,5 @@ open class MutableInputTextViewModel : MutableViewModel(), InputTextViewModel {
         userInput.value = value
     }
 
-    override val enabled = PropertyFactory.never<Boolean>()
+    override var enabled = PropertyFactory.never<Boolean>()
 }

--- a/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/mutable/MutableInputTextViewModel.kt
+++ b/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/mutable/MutableInputTextViewModel.kt
@@ -21,4 +21,6 @@ open class MutableInputTextViewModel : MutableViewModel(), InputTextViewModel {
     override fun setUserInput(value: String) {
         userInput.value = value
     }
+
+    override val enabled = PropertyFactory.never<Boolean>()
 }

--- a/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/mutable/MutableToggleSwitchViewModel.kt
+++ b/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/mutable/MutableToggleSwitchViewModel.kt
@@ -2,6 +2,7 @@ package com.mirego.trikot.viewmodels.mutable
 
 import com.mirego.trikot.streams.reactive.Publishers
 import com.mirego.trikot.viewmodels.ToggleSwitchViewModel
+import com.mirego.trikot.viewmodels.factory.PropertyFactory
 
 open class MutableToggleSwitchViewModel() : MutableViewModel(), ToggleSwitchViewModel {
 
@@ -10,4 +11,6 @@ open class MutableToggleSwitchViewModel() : MutableViewModel(), ToggleSwitchView
     override fun setIsOn(on: Boolean) {
         isOn.value = on
     }
+
+    override var enabled = PropertyFactory.never<Boolean>()
 }


### PR DESCRIPTION
## Description
Added Boolean publisher in order to handle the enable / disable state of the view

## Motivation and Context
I want to be able to enable/disable the interactions with the InputTextView and ToggleSwitch

## How Has This Been Tested?
- [x] All features has been added/updated in sample application ( /sample )
This was also tested in my app. Bindings and sample app adjustment will be in a subsequent PR since I need this new version of the lib

## Screenshots of sample application ( /sample ) (if appropriate):
<img width="487" alt="Screen Shot 2021-02-02 at 9 04 22 PM" src="https://user-images.githubusercontent.com/7625267/106687518-40b67380-659a-11eb-8f89-96a727105730.png">
<img width="559" alt="Screen Shot 2021-02-02 at 9 04 20 PM" src="https://user-images.githubusercontent.com/7625267/106687519-414f0a00-659a-11eb-9c34-a627bfa423c6.png">
<img width="487" alt="Screen Shot 2021-02-02 at 9 04 03 PM" src="https://user-images.githubusercontent.com/7625267/106687521-41e7a080-659a-11eb-8809-b624fe10830f.png">
<img width="515" alt="Screen Shot 2021-02-02 at 9 03 58 PM" src="https://user-images.githubusercontent.com/7625267/106687523-42803700-659a-11eb-9193-3624d3ee7558.png">


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
