### PR TITLE
Add JS IR compiler support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 kotlin.code.style=official
 kotlin_version=1.4.21
-trikot_foundation_version=1.0.24
-trikot_streams_version=1.0.11
-trikot_streams_android_ktx_version=1.0.1
+trikot_foundation_version=1.0.25
+trikot_streams_version=1.0.16
+trikot_streams_android_ktx_version=1.0.3
 androidx_lifecycle_version=2.2.0
 android.useAndroidX=true
 android.enableJetifier=true

--- a/viewmodels/build.gradle
+++ b/viewmodels/build.gradle
@@ -37,11 +37,8 @@ kotlin {
     iosArm32('iosArm32')
     tvos()
 
-    // Restore JS engines when failing tests are fixed
-    js()
-    js {
+    js(IR) {
         browser()
-        nodejs()
     }
 
     sourceSets {

--- a/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/properties/ViewModelAction.kt
+++ b/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/properties/ViewModelAction.kt
@@ -1,14 +1,16 @@
 package com.mirego.trikot.viewmodels.properties
 
 import com.mirego.trikot.foundation.concurrent.freeze
+import kotlin.js.JsName
 
 typealias ViewModelActionBlock = (actionContext: Any?) -> Unit
 
 open class ViewModelAction(private var action: ViewModelActionBlock) {
     fun execute() {
-        execute(null)
+        action(null)
     }
 
+    @JsName("executeWithActionContext")
     open fun execute(actionContext: Any? = null) {
         action(actionContext)
     }


### PR DESCRIPTION
The change within `ViewModelAction` was necessary because of a bug when compiled down to JS. Even if we are passing `null` as an argument, it did not call the method with an `actionContext`, it called itself recursively and caused a stack overflow 💥 