### PR TITLE
Hotfix/tvos toggle switch

### DIFF
--- a/Trikot.viewmodels.podspec
+++ b/Trikot.viewmodels.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |spec|
   spec.source_files  = "swift-extensions/*.swift"
   spec.tvos.source_files = "swift-extensions/*.swift"
   spec.tvos.exclude_files = "swift-extensions/UISliderExtensions.swift"
+  spec.tvos.exclude_files = "swift-extensions/UISwitchExtensions.swift"
 
   spec.static_framework = true
   spec.ios.deployment_target = '9.0'

--- a/Trikot.viewmodels.podspec
+++ b/Trikot.viewmodels.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
   spec.source        = { :git => "https://github.com/mirego/trikot.viewmodels.git", :tag => "#{spec.version}" }
   spec.source_files  = "swift-extensions/*.swift"
   spec.tvos.source_files = "swift-extensions/*.swift"
-  spec.tvos.exclude_files = "swift-extensions/UISliderExtensions.swift, swift-extensions/UISwitchExtensions.swift"
+  spec.tvos.exclude_files = "swift-extensions/UISliderExtensions.swift", "swift-extensions/UISwitchExtensions.swift"
 
   spec.static_framework = true
   spec.ios.deployment_target = '9.0'

--- a/Trikot.viewmodels.podspec
+++ b/Trikot.viewmodels.podspec
@@ -9,8 +9,7 @@ Pod::Spec.new do |spec|
   spec.source        = { :git => "https://github.com/mirego/trikot.viewmodels.git", :tag => "#{spec.version}" }
   spec.source_files  = "swift-extensions/*.swift"
   spec.tvos.source_files = "swift-extensions/*.swift"
-  spec.tvos.exclude_files = "swift-extensions/UISliderExtensions.swift"
-  spec.tvos.exclude_files = "swift-extensions/UISwitchExtensions.swift"
+  spec.tvos.exclude_files = "swift-extensions/UISliderExtensions.swift, swift-extensions/UISwitchExtensions.swift"
 
   spec.static_framework = true
   spec.ios.deployment_target = '9.0'


### PR DESCRIPTION
tvOS builds are failing with current version of trikot.viewmodels

## Description
Added the exclusion of the UISwitchExtensions.swift file for tvOS in the podspec

## Motivation and Context
Since a UISwitch does not exist on tvOS, the inclusion of this file causes builds to fail

## How Has This Been Tested?
The last commit of this branch was used to test and see if our personal project was fixed with this exclusion and it was.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
