### PR TITLE
Add a jenkins job so we can build from the legacy 1.0.x branch

### DIFF
--- a/jenkins-jobs/plugin_release.groovy
+++ b/jenkins-jobs/plugin_release.groovy
@@ -9,9 +9,17 @@ context.standardFolders()
 job(context.jobFullName) {
     description("Make a release of trikot.viewmodels")
     logRotator(5)
+    parameters {
+        stringParam {
+            name('Branch')
+            defaultValue("${GIT_BRANCH}")
+            description('The git branch to be built')
+            trim(true)
+        }
+    }
     scm {
         git {
-            branch("${GIT_BRANCH}")
+            branch("${Branch}")
             remote {
                 name('origin')
                 url("${GIT_URL}")
@@ -45,51 +53,20 @@ job(context.jobFullName) {
     }
 }
 
-job("$context.jobFullName-legacy-1_0_*") {
-    description("Make a release of trikot.viewmodels")
-    logRotator(5)
-    scm {
-        git {
-            branch("release/1.0.x")
-            remote {
-                name('origin')
-                url("${GIT_URL}")
-                credentials('github')
-            }
-        }
-    }
-    wrappers {
-        credentialsBinding {
-            amazonWebServicesCredentialsBinding {
-                accessKeyVariable('MAVEN_AWS_KEY')
-                secretKeyVariable('MAVEN_AWS_SECRET')
-                credentialsId('mirego-maven-aws')
-            }
-        }
-    }
-    steps {
-        gradle {
-            useWrapper()
-            makeExecutable()
-            tasks(':viewmodels:release')
-            switches('-i -s')
-        }
-    }
-    publishers {
-        slackNotifier {
-            notifyFailure(true)
-            notifyBackToNormal(true)
-            room(context.slackChannel)
-        }
-    }
-}
-
-job("$context.jobFullName-android-ktx-legacy-1_0_*") {
+job("$context.jobFullName-android-ktx-1_0_*") {
     description("Make a release of trikot.viewmodels:android-ktx")
     logRotator(5)
+    parameters {
+        stringParam {
+            name('Branch')
+            defaultValue("release/1.0.x")
+            description('The git branch to be built')
+            trim(true)
+        }
+    }
     scm {
         git {
-            branch("release/1.0.x")
+            branch("${Branch}")
             remote {
                 name('origin')
                 url("${GIT_URL}")

--- a/jenkins-jobs/plugin_release.groovy
+++ b/jenkins-jobs/plugin_release.groovy
@@ -44,3 +44,81 @@ job(context.jobFullName) {
         }
     }
 }
+
+job("$context.jobFullName-legacy-1_0_*") {
+    description("Make a release of trikot.viewmodels")
+    logRotator(5)
+    scm {
+        git {
+            branch("release/1.0.x")
+            remote {
+                name('origin')
+                url("${GIT_URL}")
+                credentials('github')
+            }
+        }
+    }
+    wrappers {
+        credentialsBinding {
+            amazonWebServicesCredentialsBinding {
+                accessKeyVariable('MAVEN_AWS_KEY')
+                secretKeyVariable('MAVEN_AWS_SECRET')
+                credentialsId('mirego-maven-aws')
+            }
+        }
+    }
+    steps {
+        gradle {
+            useWrapper()
+            makeExecutable()
+            tasks(':viewmodels:release')
+            switches('-i -s')
+        }
+    }
+    publishers {
+        slackNotifier {
+            notifyFailure(true)
+            notifyBackToNormal(true)
+            room(context.slackChannel)
+        }
+    }
+}
+
+job("$context.jobFullName-android-ktx-legacy-1_0_*") {
+    description("Make a release of trikot.viewmodels:android-ktx")
+    logRotator(5)
+    scm {
+        git {
+            branch("release/1.0.x")
+            remote {
+                name('origin')
+                url("${GIT_URL}")
+                credentials('github')
+            }
+        }
+    }
+    wrappers {
+        credentialsBinding {
+            amazonWebServicesCredentialsBinding {
+                accessKeyVariable('MAVEN_AWS_KEY')
+                secretKeyVariable('MAVEN_AWS_SECRET')
+                credentialsId('mirego-maven-aws')
+            }
+        }
+    }
+    steps {
+        gradle {
+            useWrapper()
+            makeExecutable()
+            tasks(':android-ktx:release')
+            switches('-i -s')
+        }
+    }
+    publishers {
+        slackNotifier {
+            notifyFailure(true)
+            notifyBackToNormal(true)
+            room(context.slackChannel)
+        }
+    }
+}


### PR DESCRIPTION
## Description
Allow to specify the branch we build trikot.viewmodels from + readd the android-ktx build to temporarily build from release/1.0.x by default

## Motivation and Context
There is a bug in Kotlin/Native 1.4.30 where compilation fails for projects that use `Enum.values`
While we wait for the fix in a later version of Kotlin, we still need to be able to build releases of Trikot.viewmodels that use kotlin 1.4.20

I decided against having a "parametrized" jenkins tasks to keep the normal flow simple. These additional Jobs will be removed when we get a release of Kotlin that fixes the regression

## How Has This Been Tested?
Not tested since it's an update to the build configuration.

## Types of changes
Configuration change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
