### PR TITLE
UIButton extension title color lost on ios13 when using richText

### DIFF
--- a/sample/common/src/commonMain/kotlin/com/trikot/viewModels/sample/viewModels/home/ButtonsViewModel.kt
+++ b/sample/common/src/commonMain/kotlin/com/trikot/viewModels/sample/viewModels/home/ButtonsViewModel.kt
@@ -75,7 +75,7 @@ class ButtonsViewModel(navigationDelegate: NavigationDelegate) : MutableListView
             it.button.action = ViewModelAction { navigationDelegate.showAlert("Tapped $it") }.just()
             it.button.text = "Tap me".just()
         },
-        MutableHeaderListItemViewModel(".enabled"),
+        MutableHeaderListItemViewModel(".!enabled"),
         MutableButtonListItemViewModel().also {
             it.button.enabled = false.just()
             it.button.text = "I am disabled".just()
@@ -116,7 +116,7 @@ class ButtonsViewModel(navigationDelegate: NavigationDelegate) : MutableListView
         MutableHeaderListItemViewModel("click to toggle image"),
         MutableButtonListItemViewModel().also {
             it.button.imageResource = iconVisible.map { visible ->
-                StateSelector(if (visible) ImageResources.ICON else null)
+                StateSelector(if (visible) ImageResources.ICON else ImageResource.None)
             }
             it.button.tintColor = StateSelector(Color(255, 0, 0), Color(123, 123, 123)).just()
             it.button.action = ViewModelAction {

--- a/sample/common/src/commonMain/kotlin/com/trikot/viewModels/sample/viewModels/home/LabelsViewModel.kt
+++ b/sample/common/src/commonMain/kotlin/com/trikot/viewModels/sample/viewModels/home/LabelsViewModel.kt
@@ -94,10 +94,6 @@ class LabelsViewModel(navigationDelegate: NavigationDelegate) :
                     ),
                     RichTextRange(
                         IntRange(71, 72),
-                        TextAppearanceResourceTransform(SampleTextAppearanceResource.TEXT_APPEARANCE_COLORED)
-                    ),
-                    RichTextRange(
-                        IntRange(72, 73),
                         TextAppearanceResourceTransform(SampleTextAppearanceResource.TEXT_APPEARANCE_SUPERSCRIPT)
                     )
                 )

--- a/sample/ios/Podfile
+++ b/sample/ios/Podfile
@@ -9,7 +9,7 @@ target 'iosApp' do
   use_frameworks!
   pod 'SwiftLint'
   pod 'ViewModelsSample', :path => '../common'
-  pod 'Trikot.viewmodels', :git => 'git@github.com:mirego/trikot.viewmodels.git', :inhibit_warnings => true
+  pod 'Trikot.viewmodels', :git => 'git@github.com:mirego/trikot.viewmodels.git', :tag => '1.0.16', :inhibit_warnings => true
   pod 'Trikot.streams', :git => 'git@github.com:mirego/trikot.streams.git', :inhibit_warnings => true
     
   target 'iosAppTests' do

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -13,11 +13,11 @@ PODS:
 DEPENDENCIES:
   - SwiftLint
   - "Trikot.streams (from `git@github.com:mirego/trikot.streams.git`)"
-  - "Trikot.viewmodels (from `git@github.com:mirego/trikot.viewmodels.git`)"
+  - "Trikot.viewmodels (from `git@github.com:mirego/trikot.viewmodels.git`, tag `1.0.16`)"
   - ViewModelsSample (from `../common`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - SwiftLint
 
 EXTERNAL SOURCES:
@@ -25,6 +25,7 @@ EXTERNAL SOURCES:
     :git: "git@github.com:mirego/trikot.streams.git"
   Trikot.viewmodels:
     :git: "git@github.com:mirego/trikot.viewmodels.git"
+    :tag: 1.0.16
   ViewModelsSample:
     :path: "../common"
 
@@ -33,15 +34,15 @@ CHECKOUT OPTIONS:
     :commit: 77bd2e22dab976ef292d8d7c282e4e3a84dfa384
     :git: "git@github.com:mirego/trikot.streams.git"
   Trikot.viewmodels:
-    :commit: e7cb52efb7a28c4dfabf867c4737d9d9013e1932
     :git: "git@github.com:mirego/trikot.viewmodels.git"
+    :tag: 1.0.16
 
 SPEC CHECKSUMS:
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
   Trikot.streams: 495aae8afde3c2c3c5d08124d0e1c0c038108c4d
-  Trikot.viewmodels: 68e0bf985360fda5f097a3d3d40aef65cf476ab3
+  Trikot.viewmodels: 9ac5d99289edcac8fc7391a37c29ecb250569736
   ViewModelsSample: 29f81b212b7a50e8594c43aba05578c83b8eb4d6
 
-PODFILE CHECKSUM: 785bd6160b7f5efa838834a21f591c487ea090f1
+PODFILE CHECKSUM: 3a8c21987e2bad8775e205266aff326aca9b2e97
 
 COCOAPODS: 1.9.3

--- a/sample/ios/iosApp/listitems/ButtonListItem.swift
+++ b/sample/ios/iosApp/listitems/ButtonListItem.swift
@@ -17,10 +17,10 @@ class ButtonListItem: UIView {
         button.translatesAutoresizingMaskIntoConstraints = false
 
         button.backgroundColor = #colorLiteral(red: 0.1764705882, green: 0.2196078431, blue: 0.6784313725, alpha: 1)
-        button.setTitleColor(.black, for: .normal)
+        button.setTitleColor(.yellow, for: .normal)
         button.setTitleColor(.red, for: .highlighted)
         button.setTitleColor(.blue, for: .disabled)
-        button.setTitleColor(.white, for: .selected)
+        button.setTitleColor(.green, for: .selected)
         button.titleLabel?.numberOfLines = 2
         button.titleLabel?.minimumScaleFactor = 0.4
 

--- a/sample/ios/iosApp/listitems/ButtonListItem.swift
+++ b/sample/ios/iosApp/listitems/ButtonListItem.swift
@@ -2,17 +2,21 @@ import UIKit
 import ViewModelsSample
 
 class ButtonListItem: UIView {
-    private let button = UIButton(frame: .zero)
+    private var button: UIButton?
 
     var item: ButtonListItemViewModel? {
         didSet {
+            if let button = button {
+                button.removeFromSuperview()
+            }
+            recreateButton()
             viewModel = item
-            button.buttonViewModel = item?.button
+            button?.buttonViewModel = item?.button
         }
     }
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    private func recreateButton() {
+        let button = UIButton(frame: .zero)
         addSubview(button)
         button.translatesAutoresizingMaskIntoConstraints = false
 
@@ -32,9 +36,6 @@ class ButtonListItem: UIView {
             button.centerXAnchor.constraint(equalTo: centerXAnchor),
             widthAnchor.constraint(greaterThanOrEqualTo: button.widthAnchor)
         ])
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        self.button = button
     }
 }

--- a/sample/ios/iosApp/listitems/InputTextListItem.swift
+++ b/sample/ios/iosApp/listitems/InputTextListItem.swift
@@ -6,6 +6,7 @@ class InputTextListItem: UIView {
 
     var item: InputTextListItemViewModel? {
         didSet {
+            textField.backgroundColor = nil
             viewModel = item
             textField.inputTextViewModel = item?.inputText
         }

--- a/swift-extensions/UIButtonExtensions.swift
+++ b/swift-extensions/UIButtonExtensions.swift
@@ -142,6 +142,8 @@ extension UIButton {
             let coloredAttribuedString = NSMutableAttributedString(attributedString: attributedString)
             coloredAttribuedString.addAttribute(.foregroundColor, value: color, range: NSRange(location: 0, length: attributedString.length))
             setAttributedTitle(coloredAttribuedString, for: state)
+        } else {
+            setAttributedTitle(attributedString, for: state)
         }
     }
 

--- a/swift-extensions/UIButtonExtensions.swift
+++ b/swift-extensions/UIButtonExtensions.swift
@@ -138,8 +138,10 @@ extension UIButton {
             let coloredAttribuedString = NSMutableAttributedString(attributedString: attributedString)
             coloredAttribuedString.addAttribute(.foregroundColor, value: color, range: NSRange(location: 0, length: attributedString.length))
             setAttributedTitle(coloredAttribuedString, for: state)
-        } else {
-            setAttributedTitle(attributedString, for: state)
+        } else if let color = titleColor(for: state) {
+            let coloredAttribuedString = NSMutableAttributedString(attributedString: attributedString)
+            coloredAttribuedString.addAttribute(.foregroundColor, value: color, range: NSRange(location: 0, length: attributedString.length))
+            setAttributedTitle(coloredAttribuedString, for: state)
         }
     }
 


### PR DESCRIPTION
## Description
When using UIButtonExtension in conjunction with richText for the title, the behaviour was different on iOS 14 vs older versions of iOS

ios 14: when no colorSelector set, the title color defaults to the Color set for the string title using `setTitleColor(for:)` 
ios 13: when no colorSelector set, the title color defaults back to the default colors for button, ignoring what was set with `setTitleColor(for:)`

This PR ensures that the behaviour is identical for ios 14 vs older version by grabing the appropriate color using `titleColor(for:)` when no ColorSelector is provided by the viewModel 

## Motivation and Context
Ensure that we do not end up with black text over black background on older ios versions

## How Has This Been Tested?
- [x] All features has been added/updated in sample application ( /sample )
Tested in my app plus adjusted the iOS sample to be able to test it easily on ios 13 and ios 14

## Screenshots of sample application ( /sample ) (if appropriate):
Before | After
---- | ----
![Capture d’écran, le 2021-03-02 à 11 33 55](https://user-images.githubusercontent.com/87188/109722026-1eece400-7b7a-11eb-9ad1-70ecc4e895aa.png) | ![Capture d’écran, le 2021-03-02 à 17 11 05](https://user-images.githubusercontent.com/87188/109722142-4774de00-7b7a-11eb-8c79-3f48aadd30fb.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Might be breaking for some applications but in a good way 🤔 
