### PR TITLE
Do not loose ColorTransform with default colors

### DIFF
--- a/sample/common/src/commonMain/kotlin/com/trikot/viewModels/sample/viewModels/home/ButtonsViewModel.kt
+++ b/sample/common/src/commonMain/kotlin/com/trikot/viewModels/sample/viewModels/home/ButtonsViewModel.kt
@@ -10,6 +10,7 @@ import com.mirego.trikot.viewmodels.properties.Color
 import com.mirego.trikot.viewmodels.properties.StateSelector
 import com.mirego.trikot.viewmodels.properties.ViewModelAction
 import com.mirego.trikot.viewmodels.resource.ImageResource
+import com.mirego.trikot.viewmodels.text.ColorTransform
 import com.mirego.trikot.viewmodels.text.RichText
 import com.mirego.trikot.viewmodels.text.RichTextRange
 import com.mirego.trikot.viewmodels.text.StyleTransform
@@ -46,7 +47,23 @@ class ButtonsViewModel(navigationDelegate: NavigationDelegate) : MutableListView
                 )
             ).just()
         },
-        MutableHeaderListItemViewModel(".richText with color"),
+
+        MutableHeaderListItemViewModel(".richText with color range"),
+        MutableButtonListItemViewModel().also {
+            it.button.richText = RichText(
+                "normal, bold, underlined, italic, bold italic",
+                listOf(
+                    RichTextRange(0..8, StyleTransform(StyleTransform.Style.NORMAL)),
+                    RichTextRange(8..14, StyleTransform(StyleTransform.Style.BOLD)),
+                    RichTextRange(14..26, StyleTransform(StyleTransform.Style.UNDERLINE)),
+                    RichTextRange(IntRange(14, 26), ColorTransform(Color(200,0,0))),
+                    RichTextRange(26..34, StyleTransform(StyleTransform.Style.ITALIC)),
+                    RichTextRange(34..45, StyleTransform(StyleTransform.Style.BOLD_ITALIC))
+                )
+            ).just()
+        },
+
+        MutableHeaderListItemViewModel(".richText with color selector"),
         MutableButtonListItemViewModel().also {
             it.button.textColor = StateSelector(Color(123, 123, 123), Color(0, 0, 0)).just()
             it.button.richText = RichText(
@@ -55,6 +72,21 @@ class ButtonsViewModel(navigationDelegate: NavigationDelegate) : MutableListView
                     RichTextRange(IntRange(0, 8), StyleTransform(StyleTransform.Style.NORMAL)),
                     RichTextRange(IntRange(8, 14), StyleTransform(StyleTransform.Style.BOLD)),
                     RichTextRange(IntRange(14, 26), StyleTransform(StyleTransform.Style.UNDERLINE)),
+                    RichTextRange(IntRange(26, 34), StyleTransform(StyleTransform.Style.ITALIC)),
+                    RichTextRange(IntRange(34, 45), StyleTransform(StyleTransform.Style.BOLD_ITALIC))
+                )
+            ).just()
+        },
+        MutableHeaderListItemViewModel(".richText with color selector + color range"),
+        MutableButtonListItemViewModel().also {
+            it.button.textColor = StateSelector(Color(123, 123, 123), Color(0, 0, 0)).just()
+            it.button.richText = RichText(
+                "normal, bold, underlined, italic, bold italic",
+                listOf(
+                    RichTextRange(IntRange(0, 8), StyleTransform(StyleTransform.Style.NORMAL)),
+                    RichTextRange(IntRange(8, 14), StyleTransform(StyleTransform.Style.BOLD)),
+                    RichTextRange(IntRange(14, 26), StyleTransform(StyleTransform.Style.UNDERLINE)),
+                    RichTextRange(IntRange(14, 26), ColorTransform(Color(200,0,0))),
                     RichTextRange(IntRange(26, 34), StyleTransform(StyleTransform.Style.ITALIC)),
                     RichTextRange(IntRange(34, 45), StyleTransform(StyleTransform.Style.BOLD_ITALIC))
                 )

--- a/sample/ios/Podfile
+++ b/sample/ios/Podfile
@@ -9,7 +9,7 @@ target 'iosApp' do
   use_frameworks!
   pod 'SwiftLint'
   pod 'ViewModelsSample', :path => '../common'
-  pod 'Trikot.viewmodels', :git => 'git@github.com:mirego/trikot.viewmodels.git', :tag => '1.0.16', :inhibit_warnings => true
+  pod 'Trikot.viewmodels', :git => 'git@github.com:mirego/trikot.viewmodels.git', :tag => '1.0.17', :inhibit_warnings => true
   pod 'Trikot.streams', :git => 'git@github.com:mirego/trikot.streams.git', :inhibit_warnings => true
     
   target 'iosAppTests' do

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
 DEPENDENCIES:
   - SwiftLint
   - "Trikot.streams (from `git@github.com:mirego/trikot.streams.git`)"
-  - "Trikot.viewmodels (from `git@github.com:mirego/trikot.viewmodels.git`, tag `1.0.16`)"
+  - "Trikot.viewmodels (from `git@github.com:mirego/trikot.viewmodels.git`, tag `1.0.17`)"
   - ViewModelsSample (from `../common`)
 
 SPEC REPOS:
@@ -25,7 +25,7 @@ EXTERNAL SOURCES:
     :git: "git@github.com:mirego/trikot.streams.git"
   Trikot.viewmodels:
     :git: "git@github.com:mirego/trikot.viewmodels.git"
-    :tag: 1.0.16
+    :tag: 1.0.17
   ViewModelsSample:
     :path: "../common"
 
@@ -35,7 +35,7 @@ CHECKOUT OPTIONS:
     :git: "git@github.com:mirego/trikot.streams.git"
   Trikot.viewmodels:
     :git: "git@github.com:mirego/trikot.viewmodels.git"
-    :tag: 1.0.16
+    :tag: 1.0.17
 
 SPEC CHECKSUMS:
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
@@ -43,6 +43,6 @@ SPEC CHECKSUMS:
   Trikot.viewmodels: 9ac5d99289edcac8fc7391a37c29ecb250569736
   ViewModelsSample: 29f81b212b7a50e8594c43aba05578c83b8eb4d6
 
-PODFILE CHECKSUM: 3a8c21987e2bad8775e205266aff326aca9b2e97
+PODFILE CHECKSUM: 7763ce13afefa670931e9442d5bc73fbaca0c0d8
 
 COCOAPODS: 1.9.3

--- a/swift-extensions/UIButtonExtensions.swift
+++ b/swift-extensions/UIButtonExtensions.swift
@@ -139,12 +139,21 @@ extension UIButton {
             coloredAttribuedString.addAttribute(.foregroundColor, value: color, range: NSRange(location: 0, length: attributedString.length))
             setAttributedTitle(coloredAttribuedString, for: state)
         } else if let color = titleColor(for: state) {
-            let coloredAttribuedString = NSMutableAttributedString(attributedString: attributedString)
-            coloredAttribuedString.addAttribute(.foregroundColor, value: color, range: NSRange(location: 0, length: attributedString.length))
-            setAttributedTitle(coloredAttribuedString, for: state)
+            setAttributedTitle(getAtributedString(attributedString, coloringCompletedWith: color), for: state)
         } else {
             setAttributedTitle(attributedString, for: state)
         }
+    }
+    
+    private func getAtributedString(_ attributedString: NSAttributedString, coloringCompletedWith color: UIColor) -> NSAttributedString {
+        let coloredAttribuedString = NSAttributedString(string: attributedString.string, attributes: [.foregroundColor: color])
+        let completedAttributedString = NSMutableAttributedString(attributedString: coloredAttribuedString)
+        attributedString.enumerateAttributes(in: NSRange(location: 0, length: attributedString.length), options: []) { (attributes, range, _) in
+            if !attributes.isEmpty {
+                completedAttributedString.addAttributes(attributes, range: range)
+            }
+        }
+        return completedAttributedString
     }
 
     public func positionSubviews(_ alignment: Alignment?) {


### PR DESCRIPTION
## Description
In the previous fix, we corrected the behaviour of UIButton text on iOS 13 that was not using titleColor set on the actual control when combining with rich text

That fix broke the support of using Color transform on partial ranges even when there is no color selector specified since `titleColor(for state: UIControl.State)` always return a color (it returns the defaults if none was set)

Here we simply change the priority level of the ColorTransform by applying it after the default colors so it is not lost

**Note**: I will open another PR to cherry pick this to the main branch

## Motivation and Context
Could not combine rich text and default titleColor(for state:) 

## How Has This Been Tested?
- [x] All features has been added/updated in sample application ( /sample )

## Screenshots of sample application ( /sample ) (if appropriate):
Before | After
---- | ----
![Simulator Screen Shot - iPhone 8 - 2021-03-16 at 15 20 59](https://user-images.githubusercontent.com/87188/111367704-617aea00-866b-11eb-96fd-58942a50c19f.png) | ![Simulator Screen Shot - iPhone 8 - 2021-03-16 at 15 15 21](https://user-images.githubusercontent.com/87188/111367723-663f9e00-866b-11eb-9fea-947f981848c4.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)