### PR TITLE
Replace inline class with data class to fix issue with IR JS compiler

### DIFF
--- a/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/ImageViewModel.kt
+++ b/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/ImageViewModel.kt
@@ -5,10 +5,8 @@ import com.mirego.trikot.viewmodels.properties.ImageState
 import com.mirego.trikot.viewmodels.resource.ImageResource
 import org.reactivestreams.Publisher
 
-@Suppress("EXPERIMENTAL_FEATURE_WARNING")
-inline class ImageWidth(val value: Int)
-@Suppress("EXPERIMENTAL_FEATURE_WARNING")
-inline class ImageHeight(val value: Int)
+data class ImageWidth(val value: Int)
+data class ImageHeight(val value: Int)
 
 interface ImageViewModel : ViewModel {
     fun imageFlow(width: ImageWidth, height: ImageHeight): Publisher<ImageFlow>


### PR DESCRIPTION
The inline classes didn't work with the JS IR compiler:

```
java.lang.IllegalStateException: Inline class has no field: com.mirego.trikot.viewmodels.ImageWidth
```

Replacing them for a data class resolves the issue.