### PR TITLE
Fix ApplicationStatePublisher runtime crash

### DIFF
--- a/viewmodels/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -1,6 +1,7 @@
 package com.mirego.trikot.viewmodels.lifecycle
 
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
+import kotlinx.cinterop.ObjCAction
 import org.reactivestreams.Publisher
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSThread
@@ -8,12 +9,11 @@ import platform.UIKit.UIApplication
 import platform.UIKit.UIApplicationDidEnterBackgroundNotification
 import platform.UIKit.UIApplicationState
 import platform.UIKit.UIApplicationWillEnterForegroundNotification
+import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 import platform.darwin.sel_registerName
 import kotlin.native.concurrent.freeze
-import kotlinx.cinterop.ObjCAction
-import platform.darwin.NSObject
 
 actual class ApplicationStatePublisher :
     BehaviorSubjectImpl<ApplicationState>(),
@@ -53,7 +53,7 @@ actual class ApplicationStatePublisher :
         super.onNoSubscription()
     }
 
-    private class ApplicationStateObserver: NSObject() {
+    private class ApplicationStateObserver : NSObject() {
         private var callback: ((ApplicationState) -> Unit)? = null
 
         fun start(closure: (ApplicationState) -> Unit) {

--- a/viewmodels/src/iosMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/iosMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -1,6 +1,7 @@
 package com.mirego.trikot.viewmodels.lifecycle
 
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
+import kotlinx.cinterop.ObjCAction
 import org.reactivestreams.Publisher
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSThread
@@ -8,12 +9,11 @@ import platform.UIKit.UIApplication
 import platform.UIKit.UIApplicationDidEnterBackgroundNotification
 import platform.UIKit.UIApplicationState
 import platform.UIKit.UIApplicationWillEnterForegroundNotification
+import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 import platform.darwin.sel_registerName
 import kotlin.native.concurrent.freeze
-import kotlinx.cinterop.ObjCAction
-import platform.darwin.NSObject
 
 actual class ApplicationStatePublisher :
     BehaviorSubjectImpl<ApplicationState>(),
@@ -53,7 +53,7 @@ actual class ApplicationStatePublisher :
         super.onNoSubscription()
     }
 
-    private class ApplicationStateObserver: NSObject() {
+    private class ApplicationStateObserver : NSObject() {
         private var callback: ((ApplicationState) -> Unit)? = null
 
         fun start(closure: (ApplicationState) -> Unit) {


### PR DESCRIPTION
## Description
For a selector to be called using `sel_registerName`, the method must be flagged with `@ObjCAction` and be declared in a NSObject subclass. `ApplicationStatePublisher` meet neither of these requirements.

## Motivation and Context
Using `ApplicationStatePublisher` caused a systematic runtime crash.

## How Has This Been Tested?
Tested integrated in an application

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
