### PR TITLE
Fix mutability exception on application state publisher

### DIFF
--- a/viewmodels/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -58,7 +58,8 @@ actual class ApplicationStatePublisher :
     private class ApplicationStateObserver : NSObject() {
         private var callback: ((ApplicationState) -> Unit)? by atomic(null)
 
-        init {
+        fun start(closure: (ApplicationState) -> Unit) {
+            callback = closure.freeze()
             NSNotificationCenter.defaultCenter.addObserver(
                 this,
                 sel_registerName("willEnterForeground"),
@@ -73,12 +74,9 @@ actual class ApplicationStatePublisher :
             )
         }
 
-        fun start(closure: (ApplicationState) -> Unit) {
-            callback = closure.freeze()
-        }
-
         fun stop() {
             callback = null
+            NSNotificationCenter.defaultCenter.removeObserver(this)
         }
 
         @ObjCAction

--- a/viewmodels/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -59,7 +59,7 @@ actual class ApplicationStatePublisher :
         private var callback: ((ApplicationState) -> Unit)? by atomic(null)
 
         fun start(closure: (ApplicationState) -> Unit) {
-            callback = closure
+            callback = closure.freeze()
             NSNotificationCenter.defaultCenter.addObserver(
                 this,
                 sel_registerName("willEnterForeground"),

--- a/viewmodels/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -58,8 +58,7 @@ actual class ApplicationStatePublisher :
     private class ApplicationStateObserver : NSObject() {
         private var callback: ((ApplicationState) -> Unit)? by atomic(null)
 
-        fun start(closure: (ApplicationState) -> Unit) {
-            callback = closure.freeze()
+        init {
             NSNotificationCenter.defaultCenter.addObserver(
                 this,
                 sel_registerName("willEnterForeground"),
@@ -74,9 +73,12 @@ actual class ApplicationStatePublisher :
             )
         }
 
+        fun start(closure: (ApplicationState) -> Unit) {
+            callback = closure.freeze()
+        }
+
         fun stop() {
             callback = null
-            NSNotificationCenter.defaultCenter.removeObserver(this)
         }
 
         @ObjCAction

--- a/viewmodels/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.viewmodels.lifecycle
 
+import com.mirego.trikot.foundation.concurrent.atomic
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
 import kotlinx.cinterop.ObjCAction
 import org.reactivestreams.Publisher
@@ -15,6 +16,7 @@ import platform.darwin.dispatch_get_main_queue
 import platform.darwin.sel_registerName
 import kotlin.native.concurrent.freeze
 
+@Suppress("unused")
 actual class ApplicationStatePublisher :
     BehaviorSubjectImpl<ApplicationState>(),
     Publisher<ApplicationState> {
@@ -54,7 +56,7 @@ actual class ApplicationStatePublisher :
     }
 
     private class ApplicationStateObserver : NSObject() {
-        private var callback: ((ApplicationState) -> Unit)? = null
+        private var callback: ((ApplicationState) -> Unit)? by atomic(null)
 
         fun start(closure: (ApplicationState) -> Unit) {
             callback = closure

--- a/viewmodels/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -1,6 +1,6 @@
 package com.mirego.trikot.viewmodels.lifecycle
 
-import com.mirego.trikot.foundation.concurrent.atomic
+import com.mirego.trikot.foundation.concurrent.atomicNullable
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
 import kotlinx.cinterop.ObjCAction
 import org.reactivestreams.Publisher
@@ -56,7 +56,7 @@ actual class ApplicationStatePublisher :
     }
 
     private class ApplicationStateObserver : NSObject() {
-        private var callback: ((ApplicationState) -> Unit)? by atomic(null)
+        private var callback: ((ApplicationState) -> Unit)? by atomicNullable(null)
 
         fun start(closure: (ApplicationState) -> Unit) {
             callback = closure.freeze()

--- a/viewmodels/src/iosMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/iosMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -58,7 +58,8 @@ actual class ApplicationStatePublisher :
     private class ApplicationStateObserver : NSObject() {
         private var callback: ((ApplicationState) -> Unit)? by atomic(null)
 
-        init {
+        fun start(closure: (ApplicationState) -> Unit) {
+            callback = closure.freeze()
             NSNotificationCenter.defaultCenter.addObserver(
                 this,
                 sel_registerName("willEnterForeground"),
@@ -73,12 +74,9 @@ actual class ApplicationStatePublisher :
             )
         }
 
-        fun start(closure: (ApplicationState) -> Unit) {
-            callback = closure.freeze()
-        }
-
         fun stop() {
             callback = null
+            NSNotificationCenter.defaultCenter.removeObserver(this)
         }
 
         @ObjCAction

--- a/viewmodels/src/iosMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/iosMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -59,7 +59,7 @@ actual class ApplicationStatePublisher :
         private var callback: ((ApplicationState) -> Unit)? by atomic(null)
 
         fun start(closure: (ApplicationState) -> Unit) {
-            callback = closure
+            callback = closure.freeze()
             NSNotificationCenter.defaultCenter.addObserver(
                 this,
                 sel_registerName("willEnterForeground"),

--- a/viewmodels/src/iosMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/iosMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -58,8 +58,7 @@ actual class ApplicationStatePublisher :
     private class ApplicationStateObserver : NSObject() {
         private var callback: ((ApplicationState) -> Unit)? by atomic(null)
 
-        fun start(closure: (ApplicationState) -> Unit) {
-            callback = closure.freeze()
+        init {
             NSNotificationCenter.defaultCenter.addObserver(
                 this,
                 sel_registerName("willEnterForeground"),
@@ -74,9 +73,12 @@ actual class ApplicationStatePublisher :
             )
         }
 
+        fun start(closure: (ApplicationState) -> Unit) {
+            callback = closure.freeze()
+        }
+
         fun stop() {
             callback = null
-            NSNotificationCenter.defaultCenter.removeObserver(this)
         }
 
         @ObjCAction

--- a/viewmodels/src/iosMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/iosMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.viewmodels.lifecycle
 
+import com.mirego.trikot.foundation.concurrent.atomic
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
 import kotlinx.cinterop.ObjCAction
 import org.reactivestreams.Publisher
@@ -15,6 +16,7 @@ import platform.darwin.dispatch_get_main_queue
 import platform.darwin.sel_registerName
 import kotlin.native.concurrent.freeze
 
+@Suppress("unused")
 actual class ApplicationStatePublisher :
     BehaviorSubjectImpl<ApplicationState>(),
     Publisher<ApplicationState> {
@@ -54,7 +56,7 @@ actual class ApplicationStatePublisher :
     }
 
     private class ApplicationStateObserver : NSObject() {
-        private var callback: ((ApplicationState) -> Unit)? = null
+        private var callback: ((ApplicationState) -> Unit)? by atomic(null)
 
         fun start(closure: (ApplicationState) -> Unit) {
             callback = closure

--- a/viewmodels/src/iosMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/iosMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -1,6 +1,6 @@
 package com.mirego.trikot.viewmodels.lifecycle
 
-import com.mirego.trikot.foundation.concurrent.atomic
+import com.mirego.trikot.foundation.concurrent.atomicNullable
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
 import kotlinx.cinterop.ObjCAction
 import org.reactivestreams.Publisher
@@ -56,7 +56,7 @@ actual class ApplicationStatePublisher :
     }
 
     private class ApplicationStateObserver : NSObject() {
-        private var callback: ((ApplicationState) -> Unit)? by atomic(null)
+        private var callback: ((ApplicationState) -> Unit)? by atomicNullable(null)
 
         fun start(closure: (ApplicationState) -> Unit) {
             callback = closure.freeze()


### PR DESCRIPTION
## Description
Fix a InvalidMutabilityException occurring when ApplicationStatePublisher is used from a background thread.

## Motivation and Context
Fix the following crash:
```Uncaught Kotlin exception: kotlin.native.concurrent.InvalidMutabilityException: mutation attempt of frozen <object>@81652328
    at 0   Common                         0x00000001068ca3b0 kfun:kotlin.Throwable#<init>(kotlin.String?){} + 96
    at 1   Common                         0x00000001068c1f74 kfun:kotlin.Exception#<init>(kotlin.String?){} + 92
    at 2   Common                         0x00000001068c21e4 kfun:kotlin.RuntimeException#<init>(kotlin.String?){} + 92
    at 3   Common                         0x00000001068f393c kfun:kotlin.native.concurrent.InvalidMutabilityException#<init>(kotlin.String){} + 92
    at 4   Common                         0x00000001068f4d38 ThrowInvalidMutabilityException + 336
    at 5   Common                         0x00000001070c97a4 MutationCheck + 156
    at 6   Common                         0x0000000106a0b434 kfun:com.mirego.trikot.viewmodels.lifecycle.ApplicationStatePublisher.ApplicationStateObserver.<set-callback>#internal + 108
    at 7   Common                         0x0000000106a0b60c kfun:com.mirego.trikot.viewmodels.lifecycle.ApplicationStatePublisher.ApplicationStateObserver.start#internal + 412
    at 8   Common                         0x0000000106a0afc0 kfun:com.mirego.trikot.viewmodels.lifecycle.ApplicationStatePublisher#onFirstSubscription(){} + 228
    at 9   Common                         0x00000001069b4b38 kfun:com.mirego.trikot.streams.reactive.PublishSubjectImpl.addSubscription#internal + 520
    at 10  Common                         0x00000001069b5dc4 kfun:com.mirego.trikot.streams.reactive.PublishSubjectImpl.subscribe$lambda-4#internal + 92
    at 11  Common                         0x00000001069b69e0 kfun:com.mirego.trikot.streams.reactive.PublishSubjectImpl.$subscribe$lambda-4$FUNCTION_REFERENCE$852.invoke#internal + 72
    at 12  Common                         0x00000001069b6a44 kfun:com.mirego.trikot.streams.reactive.PublishSubjectImpl.$subscribe$lambda-4$FUNCTION_REFERENCE$852.$<bridge-UNN>invoke(){}#internal + 68
    at 13  Common                         0x00000001069a1db4 kfun:com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousDispatchQueue#dispatch(kotlin.Function0<kotlin.Unit>){} + 196
    at 14  Common                         0x00000001069a0d74 kfun:com.mirego.trikot.foundation.concurrent.dispatchQueue.SequentialDispatchQueue#dispatch(kotlin.Function0<kotlin.Unit>){} + 716
    at 15  Common                         0x00000001069b4788 kfun:com.mirego.trikot.streams.reactive.PublishSubjectImpl#subscribe(org.reactivestreams.Subscriber<in|1:0>){} + 460
    at 16  Common                         0x00000001069c1490 kfun:com.mirego.trikot.streams.reactive.processors.AbstractProcessor#subscribe(org.reactivestreams.Subscriber<in|1:1>){} + 288
    at 17  Common                         0x00000001069c1490 kfun:com.mirego.trikot.streams.reactive.processors.AbstractProcessor#subscribe(org.reactivestreams.Subscriber<in|1:1>){} + 288
    at 18  Common                         0x00000001069c1490 kfun:com.mirego.trikot.streams.reactive.processors.AbstractProcessor#subscribe(org.reactivestreams.Subscriber<in|1:1>){} + 288
    at 19  Common                         0x00000001069b7200 kfun:com.mirego.trikot.streams.reactive#subscribe@org.reactivestreams.Publisher<0:0>(com.mirego.trikot.streams.cancellable.CancellableManager;kotlin.Function1<0:0,kotlin.Unit>;kotlin.Function1<kotlin.Throwable,kotlin.Unit>?;kotlin.Function0<kotlin.Unit>?){0§<kotlin.Any?>} + 392
    at 20  Common                         0x00000001069b6fa0 kfun:com.mirego.trikot.streams.reactive#subscribe@org.reactivestreams.Publisher<0:0>(com.mirego.trikot.streams.cancellable.CancellableManager;kotlin.Function1<0:0,kotlin.Unit>){0§<kotlin.Any?>} + 132
    at 21  Common                         0x0000000106d9c0e0 kfun:com.optimization.zoom.usecases.configuration.UserConfigurationUseCaseImpl#monitorUserConfiguration(com.mirego.trikot.streams.cancellable.CancellableManager){} + 472```

## How Has This Been Tested?
Will be tested in a project that can reproduce before merge

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
