### PR TITLE
Exclude UIPickerExtensions from tvOS files

### DIFF
--- a/Trikot.viewmodels.podspec
+++ b/Trikot.viewmodels.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
   spec.source        = { :git => "https://github.com/mirego/trikot.viewmodels.git", :tag => "#{spec.version}" }
   spec.source_files  = "swift-extensions/*.swift"
   spec.tvos.source_files = "swift-extensions/*.swift"
-  spec.tvos.exclude_files = "swift-extensions/UISliderExtensions.swift", "swift-extensions/UISwitchExtensions.swift"
+  spec.tvos.exclude_files = "swift-extensions/UISliderExtensions.swift", "swift-extensions/UISwitchExtensions.swift", "swift-extensions/UIPickerExtensions.swift"
 
   spec.static_framework = true
   spec.ios.deployment_target = '9.0'


### PR DESCRIPTION
## Description
Exclude `UIPickerExtensions` from tvOS file because UIPicker is not available on tv.

## Motivation and Context
Does not compile in tvOS app.

## How Has This Been Tested?
There is no sample app for tvOS 😡 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
