### PR TITLE
remove delayed enabled on click

### DIFF
--- a/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/ViewModelBinder.kt
+++ b/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/ViewModelBinder.kt
@@ -54,13 +54,9 @@ fun View.bindAction(viewModel: ViewModel, lifecycleOwnerWrapper: LifecycleOwnerW
             }
             else -> setOnClickListener { view ->
                 with(view) {
-                    isClickable = false
-                    postDelayed({ isClickable = true }, NEXT_CLICK_THRESHOLD)
                     action.execute(this)
                 }
             }
         }
     }
 }
-
-const val NEXT_CLICK_THRESHOLD = 200L


### PR DESCRIPTION
The current bindAction function would disable the viewmodel for 200ms on Android devices which isn't a behaviour we want by default. This change could potentially cause issues on projects that relied on this behaviour to prevent double clicking a UI element. Said projects will need to reimplement this part of the feature locally. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
