### PR TITLE
Android reflection based view model provider factory

### DIFF
--- a/viewmodels/build.gradle.kts
+++ b/viewmodels/build.gradle.kts
@@ -85,6 +85,18 @@ kotlin {
             }
         }
 
+        val androidTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(kotlin("test-junit"))
+                implementation("junit:junit:4.13.2")
+                implementation("androidx.test:core:1.3.0")
+                implementation("androidx.test.ext:junit:1.1.2")
+                implementation("org.robolectric:robolectric:4.5.1")
+                implementation("androidx.fragment:fragment-testing:1.3.2")
+            }
+        }
+
         val nativeMain by creating {
             dependsOn(commonMain)
         }
@@ -116,13 +128,19 @@ kotlin {
 }
 
 dependencies {
-    configurations.get("kapt").dependencies.add(DefaultExternalModuleDependency("com.android.databinding", "compiler", "3.1.4"))
+    configurations.get("kapt").dependencies.add(
+        DefaultExternalModuleDependency(
+            "com.android.databinding",
+            "compiler",
+            "3.1.4"
+        )
+    )
 }
 
 android {
     defaultConfig {
         compileSdkVersion(30)
-        minSdkVersion(14)
+        minSdkVersion(21)
         targetSdkVersion(30)
     }
 
@@ -133,6 +151,26 @@ android {
     compileOptions {
         sourceCompatibility(JavaVersion.VERSION_1_8)
         targetCompatibility(JavaVersion.VERSION_1_8)
+    }
+
+    sourceSets {
+        val test by getting {
+            manifest {
+                srcFile("src/androidTest/AndroidManifest.xml")
+            }
+        }
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 

--- a/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/AndroidViewModelProviderFactory.kt
+++ b/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/AndroidViewModelProviderFactory.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.KClass
  *              but it could be any view model.
  * Usage:
  * <pre>
- * fragment.getViewModelController(viewModelControllerFactory, ViewModel::class, arg)
+ * [fragment|activity].getViewModelController(viewModelControllerFactory, ViewModel::class)
  * </pre>
  *
  * Note: When using proguard, add exclusion rules for your ViewModelControllerFactory

--- a/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/AndroidViewModelProviderFactory.kt
+++ b/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/AndroidViewModelProviderFactory.kt
@@ -1,0 +1,198 @@
+package com.mirego.trikot.viewmodels
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kotlin.reflect.KClass
+
+/**
+ * Android extensions around a ViewModelProvider which uses reflection to instanciate
+ * view models and optionally pass it a string argument. The argument is passed to the activity
+ * intent and the fragment arguments.
+ *
+ * Terminology: viewModelController is simply the root view model for the activity / fragment .
+ *              but it could be any view model.
+ * Usage:
+ * <pre>
+ * fragment.getViewModelController(viewModelControllerFactory, ViewModel::class, arg)
+ * </pre>
+ *
+ * Note: When using proguard, add exclusion rules for your ViewModelControllerFactory
+ * <pre>
+ * -keepclassmembers class * implements com.acme.app.ViewModelControllerFactory { <methods>; }
+ * </pre>
+ */
+
+private const val KEY_SERIALIZED_DATA = "AndroidViewModelFactory.SerializedData"
+
+fun <T : ViewModel> Fragment.getViewModelController(
+    viewModelControllerFactory: Any,
+    requestedClass: KClass<T>
+): T {
+    return AndroidViewModelProviderFactory.with(
+        viewModelControllerFactory,
+        this,
+        extraSerializedData
+    )
+        .get(requestedClass.java)
+}
+
+fun <T : ViewModel> Fragment.getViewModelController(
+    viewModelControllerFactory: Any,
+    requestedClass: KClass<T>,
+    serializedData: String
+): T {
+    return AndroidViewModelProviderFactory.with(viewModelControllerFactory, this, serializedData)
+        .get(serializedData, requestedClass.java)
+}
+
+fun <T : ViewModel> FragmentActivity.getViewModelController(
+    viewModelControllerFactory: Any,
+    requestedClass: KClass<T>
+): T =
+    AndroidViewModelProviderFactory.with(viewModelControllerFactory, this, extraSerializedData)
+        .get(requestedClass.java)
+
+fun <T : ViewModel> FragmentActivity.getViewModelController(
+    viewModelControllerFactory: Any,
+    requestedClass: KClass<T>,
+    serializedData: String
+): T =
+    AndroidViewModelProviderFactory.with(viewModelControllerFactory, this, serializedData)
+        .get(serializedData, requestedClass.java)
+
+val FragmentActivity.extraSerializedData: String?
+    get() = intent.getStringExtra(KEY_SERIALIZED_DATA)
+
+fun Intent.extraSerializedData(serializedData: String) = apply {
+    putExtra(KEY_SERIALIZED_DATA, serializedData)
+}
+
+fun Bundle.extraSerializedData(serializedData: String) = apply {
+    putString(KEY_SERIALIZED_DATA, serializedData)
+}
+
+val Fragment.extraSerializedData: String?
+    get() = arguments?.getString(KEY_SERIALIZED_DATA)
+
+class AndroidViewModelProviderFactory {
+
+    companion object {
+        @JvmStatic
+        fun with(
+            viewModelControllerFactory: Any,
+            activity: FragmentActivity,
+            constructorParam: Any?
+        ) = constructorParam?.let {
+            with(viewModelControllerFactory, activity, listOf(it))
+        } ?: with(viewModelControllerFactory, activity)
+
+        @JvmStatic
+        fun with(viewModelControllerFactory: Any, fragment: Fragment, constructorParam: Any?) =
+            constructorParam?.let {
+                with(viewModelControllerFactory, fragment, listOf(it))
+            } ?: with(viewModelControllerFactory, fragment)
+
+        @JvmStatic
+        fun <T : ViewModel> get(
+            viewModelControllerFactory: Any,
+            activity: FragmentActivity,
+            serializedData: String?,
+            clazz: Class<T>
+        ) =
+            with(viewModelControllerFactory, activity, serializedData).getWithNullableKey(
+                serializedData,
+                clazz
+            )
+
+        @JvmStatic
+        fun <T : ViewModel> get(
+            viewModelControllerFactory: Any,
+            fragment: Fragment,
+            serializedData: String?,
+            clazz: Class<T>
+        ) =
+            with(viewModelControllerFactory, fragment, serializedData).getWithNullableKey(
+                serializedData,
+                clazz
+            )
+
+        private fun <T : ViewModel> ViewModelProvider.getWithNullableKey(
+            serializedData: String?,
+            clazz: Class<T>
+        ) =
+            if (serializedData == null) get(clazz) else get(serializedData, clazz)
+
+        private fun with(
+            viewModelControllerFactory: Any,
+            activity: FragmentActivity,
+            constructorParams: List<Any> = listOf()
+        ) =
+            ViewModelProvider(
+                activity.viewModelStore,
+                ParametrizedFactory(viewModelControllerFactory, constructorParams)
+            )
+
+        private fun with(
+            viewModelControllerFactory: Any,
+            fragment: Fragment,
+            constructorParams: List<Any> = listOf()
+        ) =
+            ViewModelProvider(
+                fragment.viewModelStore,
+                ParametrizedFactory(
+                    viewModelControllerFactory,
+                    constructorParams
+                )
+            )
+    }
+
+    class ParametrizedFactory(
+        private val viewModelControllerFactory: Any,
+        private val constructorParams: List<Any>
+    ) : ViewModelProvider.Factory {
+        private val viewModelControllerFactoryClass = viewModelControllerFactory::class.java
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+            val getters = viewModelControllerFactoryClass.declaredMethods
+                .filter {
+                    it.returnType == modelClass && it.parameterTypes.map { javaClass ->
+                        javaClass.kotlin
+                    } == constructorParams.map { constructorParam ->
+                        constructorParam::class
+                    }
+                }
+
+            if (getters.isEmpty()) {
+                throw IllegalArgumentException(
+                    "Unable to find a method for class: ${viewModelControllerFactoryClass.simpleName} with return type: ${modelClass.simpleName} and ${getParametersErrorString()}"
+                )
+            } else if (getters.size > 1) {
+                throw IllegalArgumentException(
+                    "Found more than one method for class: ${viewModelControllerFactoryClass.simpleName} with return type: ${modelClass.simpleName} and ${getParametersErrorString()}"
+                )
+            }
+
+            return getters[0].invoke(
+                viewModelControllerFactory,
+                *constructorParams.toTypedArray()
+            ) as T
+        }
+
+        private fun getParametersErrorString(): String {
+            if (constructorParams.isEmpty()) {
+                return "no parameters"
+            }
+
+            return "parameters: ${
+                constructorParams.joinToString(
+                    separator = ", "
+                ) { it::class.java.simpleName }
+            }"
+        }
+    }
+}

--- a/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/AndroidViewModelProviderFactory.kt
+++ b/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/AndroidViewModelProviderFactory.kt
@@ -189,9 +189,9 @@ class AndroidViewModelProviderFactory {
             }
 
             return "parameters: ${
-                constructorParams.joinToString(
-                    separator = ", "
-                ) { it::class.java.simpleName }
+            constructorParams.joinToString(
+                separator = ", "
+            ) { it::class.java.simpleName }
             }"
         }
     }

--- a/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/AndroidViewModelProviderFactory.kt
+++ b/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/AndroidViewModelProviderFactory.kt
@@ -2,8 +2,8 @@ package com.mirego.trikot.viewmodels
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import kotlin.reflect.KClass
@@ -49,14 +49,14 @@ fun <T : ViewModel> Fragment.getViewModelController(
         .get(serializedData, requestedClass.java)
 }
 
-fun <T : ViewModel> FragmentActivity.getViewModelController(
+fun <T : ViewModel> ComponentActivity.getViewModelController(
     viewModelControllerFactory: Any,
     requestedClass: KClass<T>
 ): T =
     AndroidViewModelProviderFactory.with(viewModelControllerFactory, this, extraSerializedData)
         .get(requestedClass.java)
 
-fun <T : ViewModel> FragmentActivity.getViewModelController(
+fun <T : ViewModel> ComponentActivity.getViewModelController(
     viewModelControllerFactory: Any,
     requestedClass: KClass<T>,
     serializedData: String
@@ -64,7 +64,7 @@ fun <T : ViewModel> FragmentActivity.getViewModelController(
     AndroidViewModelProviderFactory.with(viewModelControllerFactory, this, serializedData)
         .get(serializedData, requestedClass.java)
 
-val FragmentActivity.extraSerializedData: String?
+val ComponentActivity.extraSerializedData: String?
     get() = intent.getStringExtra(KEY_SERIALIZED_DATA)
 
 fun Intent.extraSerializedData(serializedData: String) = apply {
@@ -84,7 +84,7 @@ class AndroidViewModelProviderFactory {
         @JvmStatic
         fun with(
             viewModelControllerFactory: Any,
-            activity: FragmentActivity,
+            activity: ComponentActivity,
             constructorParam: Any?
         ) = constructorParam?.let {
             with(viewModelControllerFactory, activity, listOf(it))
@@ -99,7 +99,7 @@ class AndroidViewModelProviderFactory {
         @JvmStatic
         fun <T : ViewModel> get(
             viewModelControllerFactory: Any,
-            activity: FragmentActivity,
+            activity: ComponentActivity,
             serializedData: String?,
             clazz: Class<T>
         ) =
@@ -128,7 +128,7 @@ class AndroidViewModelProviderFactory {
 
         private fun with(
             viewModelControllerFactory: Any,
-            activity: FragmentActivity,
+            activity: ComponentActivity,
             constructorParams: List<Any> = listOf()
         ) =
             ViewModelProvider(

--- a/viewmodels/src/androidTest/AndroidManifest.xml
+++ b/viewmodels/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.mirego.trikot.viewmodels.android">
+    <application>
+        <activity android:name="com.mirego.trikot.viewmodels.TestActivity" />
+    </application>
+</manifest>

--- a/viewmodels/src/androidTest/kotlin/com/mirego/trikot/viewmodels/AndroidViewModelProviderFactoryTest.kt
+++ b/viewmodels/src/androidTest/kotlin/com/mirego/trikot/viewmodels/AndroidViewModelProviderFactoryTest.kt
@@ -1,0 +1,154 @@
+package com.mirego.trikot.viewmodels
+
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModel
+import androidx.test.core.app.ActivityScenario.launch
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.assertNotNull
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class AndroidViewModelProviderFactoryTest {
+
+    private val viewModelFactory = TestViewModelFactory()
+
+    @Test
+    fun testFragment_noArguments() {
+        launchFragmentInContainer<TestFragment>().apply {
+            moveToState(Lifecycle.State.CREATED)
+            onFragment { fragment ->
+                val viewModelController1 = fragment.getViewModelController(
+                    viewModelFactory,
+                    TestViewModel1::class
+                )
+                assertNotNull(viewModelController1)
+            }
+        }
+    }
+
+    @Test
+    fun testFragment_withArguments() {
+        launchFragmentInContainer<TestFragment>(
+            Bundle()
+                .extraSerializedData("expected arg")
+        ).apply {
+            moveToState(Lifecycle.State.CREATED)
+            onFragment { fragment ->
+                val viewModelControllerArg1 = fragment.getViewModelController(
+                    viewModelFactory,
+                    TestViewModelArg1::class
+                )
+                assertNotNull(viewModelControllerArg1)
+                assertEquals("expected arg", viewModelControllerArg1.arg)
+            }
+        }
+    }
+
+    @Test
+    fun testActivity_noArguments() {
+        launch(TestActivity::class.java).apply {
+            moveToState(Lifecycle.State.CREATED)
+            onActivity { activity ->
+                val viewModelController1 = activity.getViewModelController(
+                    viewModelFactory,
+                    TestViewModel1::class
+                )
+                assertNotNull(viewModelController1)
+            }
+        }
+    }
+
+    @Test
+    fun testActivity_withArguments() {
+        launch<TestActivity>(
+            Intent(getApplicationContext(), TestActivity::class.java)
+                .extraSerializedData("expected arg")
+        ).apply {
+            moveToState(Lifecycle.State.CREATED)
+            onActivity { activity ->
+                val viewModelControllerArg1 = activity.getViewModelController(
+                    viewModelFactory,
+                    TestViewModelArg1::class
+                )
+                assertNotNull(viewModelControllerArg1)
+                assertEquals("expected arg", viewModelControllerArg1.arg)
+            }
+        }
+    }
+
+    @Test
+    fun testFragment_viewModelDoesntExist() {
+        launchFragmentInContainer<TestFragment>().apply {
+            moveToState(Lifecycle.State.CREATED)
+            onFragment { fragment ->
+                assertThrows(IllegalArgumentException::class.java) {
+                    fragment.getViewModelController(
+                        viewModelFactory,
+                        TestViewModelNotExist::class
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testActivity_viewModelDoesntExist() {
+        launch(TestActivity::class.java).apply {
+            moveToState(Lifecycle.State.CREATED)
+            onActivity { activity ->
+                assertThrows(IllegalArgumentException::class.java) {
+                    activity.getViewModelController(
+                        viewModelFactory,
+                        TestViewModelNotExist::class
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testActivity_wrongArgs() {
+        launch(TestActivity::class.java).apply {
+            moveToState(Lifecycle.State.CREATED)
+            onActivity { activity ->
+                assertThrows(IllegalArgumentException::class.java) {
+                    activity.getViewModelController(
+                        viewModelFactory,
+                        TestViewModelWrongArgs::class,
+                        "abc"
+                    )
+                }
+            }
+        }
+    }
+}
+
+class TestFragment : Fragment()
+class TestActivity : FragmentActivity()
+
+private class TestViewModelFactory {
+    fun test1() = TestViewModel1()
+    fun test2() = TestViewModel2()
+    fun testArgs1(arg: String) = TestViewModelArg1(arg)
+    fun testArgs2(arg: String) = TestViewModelArg2(arg)
+    fun testWrongArgs(arg1: String, arg2: String) = TestViewModelWrongArgs()
+}
+
+private class TestViewModel1 : ViewModel()
+private class TestViewModel2 : ViewModel()
+private class TestViewModelArg1(val arg: String) : ViewModel()
+private class TestViewModelArg2(val arg: String) : ViewModel()
+private class TestViewModelNotExist : ViewModel()
+private class TestViewModelWrongArgs : ViewModel()


### PR DESCRIPTION
## Description
Add view model provider factory which uses reflection to load view model (controllers) and allows to pass string parameters as argument to fragment or activity.

We've chosen JSON to pass arguments to view models cross platform hence the choise of string parameter here. We could add other type of cross platform serialization format if need be.

## Motivation and Context
This allows creating view model on android with less boilerplate than having to instanciate them manually by providing a custom ViewModelFactory for each different type. It comes with a slight performance overhead.

## How Has This Been Tested?
Unit tested with roboelectric and battle tested in an app.

## Note
This is a more generic version of what we used in another project (cudos to @mathieularue for the original idea and implementation).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
