### PR TITLE
Rebind view holder binding after detach / attach

### DIFF
--- a/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/adapter/ViewModelAdapter.kt
+++ b/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/adapter/ViewModelAdapter.kt
@@ -115,6 +115,9 @@ open class ViewModelAdapter<MLI : ListItemViewModel>(
 
     inner class ViewHolder<out V : ViewDataBinding>(val binding: V) :
         LifecycleViewHolder(binding.root), LifecycleOwner {
+
+        private var detached = false
+
         init {
             binding.lifecycleOwner = this
             binding.setVariable(lifecycleVariableId, LifecycleOwnerWrapper(this))
@@ -122,6 +125,19 @@ open class ViewModelAdapter<MLI : ListItemViewModel>(
 
         fun setVariable(item: MLI) {
             binding.setVariable(viewModelVariableId, item)
+        }
+
+        override fun onAttach() {
+            super.onAttach()
+            if (detached) {
+                binding.invalidateAll()
+                detached = false
+            }
+        }
+
+        override fun onDetach() {
+            super.onDetach()
+            detached = true
         }
 
         fun bind(item: MLI) {


### PR DESCRIPTION
## Description
Once a view holder is detached and its lifecycle is destroyed. We need to invalidate its bindings so that it re-executes them and uses the new lifecycle owner.

## Motivation and Context
https://github.com/mirego/trikot.viewmodels/pull/103 was introduced to fix a double binding issue when the view was never bound before. It broke the behavior when a view is detached and re-attached, the binding wasn't executed, leading to updates to the viewmodel not updating the view.

## How Has This Been Tested?
The binding is done only once on the first bind, and properly called after a detach / attach.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
