### PR TITLE
add UITextViewExtensions to be compatible with LabelViewModel

### DIFF
--- a/swift-extensions/UITextViewExtensions.swift
+++ b/swift-extensions/UITextViewExtensions.swift
@@ -7,7 +7,14 @@ extension UITextView {
         set(value) {
             viewModel = value
             if let labelViewModel = value {
-                bind(labelViewModel.text, \UITextView.text)
+                if let richText = labelViewModel.richText, let font = self.font {
+                    observe(richText) {[weak self] (richText: RichText) in
+                        guard let self = self else { return }
+                        self.attributedText = self.richTextToAttributedString(richText, referenceFont: font)
+                    }
+                } else {
+                    bind(labelViewModel.text, \UITextView.text)
+                }
                 bindColorSelectorDefaultValue(labelViewModel.textColor, \UITextView.textColor)
             }
         }

--- a/swift-extensions/UITextViewExtensions.swift
+++ b/swift-extensions/UITextViewExtensions.swift
@@ -1,0 +1,15 @@
+import UIKit
+import TRIKOT_FRAMEWORK_NAME
+
+extension UITextView {
+    public var labelViewModel: LabelViewModel? {
+        get { trikotViewModel() }
+        set(value) {
+            viewModel = value
+            if let labelViewModel = value {
+                bind(labelViewModel.text, \UITextView.text)
+                bindColorSelectorDefaultValue(labelViewModel.textColor, \UITextView.textColor)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR adds extensions for UITextView to be compatible with LabelViewModels

## Motivation and Context
Previously, UITextViews were not able to show text via a Trikot Viewmodel.

## How Has This Been Tested?
- [ ] All features has been added/updated in sample application ( /sample )
This has been tested on the current project I am working on

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
