### PR TITLE
add build task to the checkTasks

### DIFF
--- a/viewmodels/build.gradle.kts
+++ b/viewmodels/build.gradle.kts
@@ -200,7 +200,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
 }
 
 release {
-    checkTasks = listOf("check")
+    checkTasks = listOf("build", "check")
     buildTasks = listOf("publish")
     updateVersionPart = 2
 }


### PR DESCRIPTION
## Description
Adding the build task to the checkTasks will ensure that Jenkins will fail before creating a git tag (if building fails)

## Motivation and Context
When Jenkins fails a build, a git tag may still be created. This may confuse users since some tags may not build correctly.
