### PR TITLE
fix UIPicker extension where row selection was happening before elements were loaded

### DIFF
--- a/swift-extensions/UIPickerExtensions.swift
+++ b/swift-extensions/UIPickerExtensions.swift
@@ -23,14 +23,14 @@ extension UIPickerView {
             guard let pickerViewModel = value else { return }
 
             self.delegate = self
-            observe(pickerViewModel.selectedElementIndex) { [weak self] (value: Int) in
-                self?.selectRow(value, inComponent: 0, animated: false)
-            }
-
             observe(pickerViewModel.elements) { [weak self] (value: [PickerItemViewModel]) in
                 self?.elements = value.map {
                     $0.displayName
                 }
+            }
+
+            observe(pickerViewModel.selectedElementIndex) { [weak self] (value: Int) in
+                self?.selectRow(value, inComponent: 0, animated: false)
             }
             
             bind(pickerViewModel.enabled, \UIPickerView.isUserInteractionEnabled)

--- a/swift-extensions/UIPickerExtensions.swift
+++ b/swift-extensions/UIPickerExtensions.swift
@@ -23,14 +23,19 @@ extension UIPickerView {
             guard let pickerViewModel = value else { return }
 
             self.delegate = self
-            observe(pickerViewModel.elements) { [weak self] (value: [PickerItemViewModel]) in
-                self?.elements = value.map {
+            
+            let pickerViewModelCombineLatest = CombineLatestProcessorExtensionsKt.combine(pickerViewModel.elements, publishers: [pickerViewModel.selectedElementIndex])
+            
+            observe(pickerViewModelCombineLatest) { [weak self] (value: [Any?]) in
+                guard let elements = value[0] as? [PickerItemViewModel],
+                      let selectedIndex = value[1] as? Int else { return }
+                
+                self?.elements = elements.map {
                     $0.displayName
                 }
-            }
-
-            observe(pickerViewModel.selectedElementIndex) { [weak self] (value: Int) in
-                self?.selectRow(value, inComponent: 0, animated: false)
+                
+                self?.selectRow(selectedIndex, inComponent: 0, animated: false)
+                
             }
             
             bind(pickerViewModel.enabled, \UIPickerView.isUserInteractionEnabled)


### PR DESCRIPTION
## Description
The UIPicker extension was observing the selectedIndex before setting the data inside of it. As a result, the picker was always showing position zero as the selected index

## Motivation and Context
In my project, the picker was always initialized at position zero even though in some cases, it shouldn't have been the case.

## How Has This Been Tested?
This has been tested locally in my project

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
