### PR TITLE
Add ApplicationState implementation on Web using document.visibilitychange event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.4.0
+> 2021-11-09
+- Added Web `ApplicationState` foreground/background support using `document.visibilitychange` event 
+
 ## 2.3.0
 > 2021-11-01
 - Updated Kotlin version to `1.5.31`

--- a/viewmodels/gradle.properties
+++ b/viewmodels/gradle.properties
@@ -1,2 +1,2 @@
 #Mon Aug 23 15:16:25 EDT 2021
-version=2.3.1-SNAPSHOT
+version=2.4.0-SNAPSHOT

--- a/viewmodels/src/jsMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/viewmodels/src/jsMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -1,7 +1,44 @@
 package com.mirego.trikot.viewmodels.lifecycle
 
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
+import kotlinx.browser.document
 import org.reactivestreams.Publisher
+import org.w3c.dom.events.Event
+import org.w3c.dom.events.EventListener
 
 actual class ApplicationStatePublisher :
-    BehaviorSubjectImpl<ApplicationState>(ApplicationState.FOREGROUND), Publisher<ApplicationState>
+    BehaviorSubjectImpl<ApplicationState>(ApplicationState.FOREGROUND),
+    Publisher<ApplicationState> {
+
+    private val visibilityChangeEventListener =
+        VisibilityChangeEventListener(this)
+
+    companion object {
+        private const val VISIBILITY_CHANGE_EVENT = "visibilitychange"
+        private const val VISIBILITY_STATE_HIDDEN = "hidden"
+    }
+
+    override fun onFirstSubscription() {
+        super.onFirstSubscription()
+        document.addEventListener(VISIBILITY_CHANGE_EVENT, visibilityChangeEventListener)
+    }
+
+    override fun onNoSubscription() {
+        document.removeEventListener(VISIBILITY_CHANGE_EVENT, visibilityChangeEventListener)
+        super.onNoSubscription()
+    }
+
+    private class VisibilityChangeEventListener(
+        val applicationStatePublisher: ApplicationStatePublisher
+    ) : EventListener {
+        override fun handleEvent(event: Event) {
+            val document: dynamic = document
+            applicationStatePublisher.value =
+                if (document.visibilityState == VISIBILITY_STATE_HIDDEN) {
+                    ApplicationState.BACKGROUND
+                } else {
+                    ApplicationState.FOREGROUND
+                }
+        }
+    }
+}


### PR DESCRIPTION
## Description

The `jsMain` current implementation of the `ApplicationStatePublisher` started as `FOREGROUND` and never changed.

Using the Document `visibilitychange` event, we can use the `document.visibilityState` property to determine the current state of the application. (See reference here: https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event)

## Motivation and Context

The analytics coverage in our project required us to provide information on the state of the application, so instead of doing it in the project itself, I bring it to our Trikot libs directly. 

## How Has This Been Tested?
- [x] All features has been added/updated in sample application ( /sample )

Published the library as a local SNAPSHOT and confirmed that the behavior is as expected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Web applications will now receive an updated value (`ApplicationState.FOREGROUND`) from `ApplicationStatePublisher` when a user loses focus of his/her browser tab, closes the tabs, or kills the browser.