### PR TITLE
Convert Color class to data class

### DIFF
--- a/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/properties/Color.kt
+++ b/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/properties/Color.kt
@@ -3,7 +3,7 @@ package com.mirego.trikot.viewmodels.properties
 import com.mirego.trikot.foundation.concurrent.freeze
 import kotlin.math.roundToInt
 
-class Color(val red: Int, val green: Int, val blue: Int, val alpha: Float = 1.0f) {
+data class Color(val red: Int, val green: Int, val blue: Int, val alpha: Float = 1.0f) {
     private val alphaHex: String
         get() {
             return toHex((alpha * 255).roundToInt())
@@ -28,5 +28,7 @@ class Color(val red: Int, val green: Int, val blue: Int, val alpha: Float = 1.0f
 
     companion object {
         val None = freeze(Color(-1, -1, -1, -1f))
+        val Black = freeze(Color(0, 0, 0))
+        val White = freeze(Color(255, 255, 255))
     }
 }


### PR DESCRIPTION
## Description
- Make the Color a data class so that it's easy to compare colors
- Add White and Black colors in the companion object since the

## Motivation and Context
In my current project, we want to know if two colors are the same and the only way we can do that is to compares the red, green, blue and alpha values. This will not be necessary if we make the Color class a data class.

Also, black and white are colors that are commonly used throughout my project (and probably other projects) so having them in a companion object is quite useful so that we don't have to create a new instance every time we need one or the other.


## How Has This Been Tested?
- [x] All features has been added/updated in sample application ( /sample )
This has been tested in the sample application and in the project I work on.

## Screenshots of sample application ( /sample ) (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
